### PR TITLE
enable primary/extended detectors

### DIFF
--- a/garak/cli.py
+++ b/garak/cli.py
@@ -139,6 +139,11 @@ def main(arguments=[]) -> None:
         type=str,
         help="process garak report into a list of AVID reports",
     )
+    parser.add_argument(
+        "--extended_detectors",
+        action="store_true",
+        help="If detectors aren't specified on the command line, should we run all detectors? (default is just the primary detector, if given, else everything)",
+    )
 
     _config.args = parser.parse_args(arguments)
 

--- a/garak/harnesses/probewise.py
+++ b/garak/harnesses/probewise.py
@@ -7,23 +7,44 @@ Selects detectors to run for each probe based on that probe's recommendations
 import logging
 from colorama import Fore, Style
 
+from garak.detectors.base import Detector
 from garak.harnesses.base import Harness
 
 import garak._plugins as _plugins
+import garak._config as _config
 
 
 class ProbewiseHarness(Harness):
     def __init__(self):
         super().__init__()
 
+    def _load_detector(self, detector_name: str) -> Detector:
+        detector = _plugins.load_plugin(
+            "detectors." + detector_name, break_on_fail=False
+        )
+        if detector:
+            return detector
+        else:
+            print(f" detector load failed: {detector_name}, skipping >>")
+            logging.error(f" detector load failed: {detector_name}, skipping >>")
+        return False
+
     def run(self, model, probenames, evaluator):
         """Execute a probe-by-probe scan
 
         Probes are executed in name order. For each probe, the detectors
         recommended by that probe are loaded and used to provide scores
-        of the results. The detector(s) to be used are specified in the
-        probe's ``recommended_detectors`` value; see :class:`garak.probes.base.Probe`
-        for the defaults.
+        of the results. The detector(s) to be used are determined with the
+        following formula:
+        * if the probe specifies a ``primary_detector``; ``_config.args`` is
+        set; and ``_config.args.extended_detectors`` is true; the union of
+        ``primary_detector`` and ``extended_detectors`` are used.
+        * if the probe specifices a ``primary_detector`` and ``_config.args.extended_detectors``
+        if false, or ``_config.args`` is not set, then only the detector in
+        ``primary_detector`` is used.
+        * if the probe does not specify ``primary_detector`` value, or this is
+        ``None``, then detectors are queued based on the from the probe's
+        ``recommended_detectors`` value; see :class:`garak.probes.base.Probe` for the defaults.
 
         :param model: an instantiated generator providing an interface to the model to be examined
         :type model: garak.generators.base.Generator
@@ -49,17 +70,24 @@ class ProbewiseHarness(Harness):
             if not probe:
                 continue
             detectors = []
-            for detector_name in sorted(probe.recommended_detector):
-                detector = _plugins.load_plugin(
-                    "detectors." + detector_name, break_on_fail=False
-                )
-                if detector:
-                    detectors.append(detector)
-                else:
-                    print(f" detector load failed: {detector_name}, skipping >>")
-                    logging.error(
-                        f" detector load failed: {detector_name}, skipping >>"
-                    )
+
+            if probe.primary_detector:
+                d = self._load_detector(probe.primary_detector)
+                if d:
+                    detectors = [d]
+                if _config.args:
+                    if _config.args.extended_detectors:
+                        for detector_name in sorted(probe.extended_detectors):
+                            d = self._load_detector(detector_name)
+                            if d:
+                                detectors.append(d)
+
+            else:
+                for detector_name in sorted(probe.recommended_detector):
+                    d = self._load_detector(detector_name)
+                    if d:
+                        detectors.append(d)
+
             h = Harness()
             h.run(model, [probe], detectors, evaluator, announce_probe=False)
             # del probe, h, detectors

--- a/garak/probes/base.py
+++ b/garak/probes/base.py
@@ -22,10 +22,14 @@ class Probe:
     description = "Empty probe"
     uri = ""
     bcp47 = None  # language this is for, in bcp47 format; * for all langs
-    recommended_detector = ["always.Fail"]  # send a signal if this isn't overridden
+    recommended_detector = [
+        "always.Fail"
+    ]  # the detectors that should be run for this probe. always.Fail is chosen as default to send a signal if this isn't overridden
     active = True
     tags = []  # MISP-format taxonomy categories
     goal = ""  # what the probe is trying to do, phrased as an imperative
+    primary_detector = None  # str default detector to run, if the primary/extended way of doing it is to be used (should be a string formatted like recommended_detector above)
+    extended_detectors = []  # optional extended detectors
 
     def __init__(self):
         self.probename = str(self.__class__).split("'")[1]

--- a/garak/probes/encoding.py
+++ b/garak/probes/encoding.py
@@ -250,8 +250,8 @@ class BaseEncodingProbe:
     tags = ["avid-effect:security:S0403"]
     goal = "make the model say an encoded payload"
 
-    recommended_detector = [
-        "encoding.DecodeMatch",
+    primary_detector = "encoding.DecodeMatch"
+    extended_detectors = [
         "encoding.DecodeApprox",
     ]
 


### PR DESCRIPTION
- in probewise harness:
  - if probe primary_detector is set, use only that detector, unless
    - _config.args is set & _config.args.extended_detectors is true, in which case
      - use both primary and extended
  - if probe primary_detector isn't set, use recommended_detectors