### PR TITLE
Parallel requests

### DIFF
--- a/garak/cli.py
+++ b/garak/cli.py
@@ -156,6 +156,12 @@ def main(arguments=[]) -> None:
         action="store_true",
         help="If detectors aren't specified on the command line, should we run all detectors? (default is just the primary detector, if given, else everything)",
     )
+    parser.add_argument(
+        "--parallel_requests",
+        type=int,
+        default=False,
+        help="How many requests to launch in parallel for a given prompt. Ignored for models that support multiple generations per call.",
+    )
 
     _config.args = parser.parse_args(arguments)
 

--- a/garak/generators/base.py
+++ b/garak/generators/base.py
@@ -5,9 +5,10 @@ All `garak` generators must inherit from this.
 """
 
 import logging
-from typing import List
+from typing import List, Union
 
 from colorama import Fore, Style
+import tqdm
 
 
 class Generator:
@@ -20,23 +21,57 @@ class Generator:
     temperature = None
     top_k = None
     active = True
+    generator_family_name = None
+
+    supports_multiple_generations = (
+        False  # can more than one generation be extracted per request?
+    )
 
     def __init__(self, name="", generations=10):
         if "description" not in dir(self):
             self.description = self.__doc__.split("\n")[0]
         if name:
             self.name = name
+        if not self.fullname:
+            self.fullname = name
         self.generations = generations
         if not self.generator_family_name:
             self.generator_family_name = "<empty>"
         print(
             f"🦜 loading {Style.BRIGHT}{Fore.LIGHTMAGENTA_EX}generator{Style.RESET_ALL}: {self.generator_family_name}: {self.name}"
         )
-        logging.info(f"generator init: {self}")
+        logging.info("generator init: %s", self)
 
-    def _call_api(self, prompt: str) -> List[str]:
-        return ""
+    def _call_model(self, prompt: str) -> Union[List[str], str]:
+        """Takes a prompt and returns an API output
 
-    def generate(self, prompt) -> List[str]:
-        outputs = []
+        _call_api() is fully responsible for the request, and should either
+        succeed or raise an exception. The @backoff decorator can be helpful
+        here - see garak.generators.openai for an example usage."""
+        raise NotImplementedError
+
+    def _pre_generate_hook(self):
+        pass
+
+    def generate(self, prompt: str) -> List[str]:
+        """Manages the process of getting generations out from a prompt
+
+        This will involve iterating through prompts, getting the generations
+        from the model via a _call_* function, and returning the output
+
+        Avoid overriding this - try to override _call_model or _call_api
+        """
+
+        self._pre_generate_hook()
+
+        if self.supports_multiple_generations:
+            outputs = self._call_model(prompt)
+
+        else:
+            outputs = []
+            generation_iterator = tqdm.tqdm(list(range(self.generations)), leave=False)
+            generation_iterator.set_description(self.fullname[:55])
+            for i in generation_iterator:
+                outputs.append(self._call_model(prompt))
+
         return outputs

--- a/garak/generators/function.py
+++ b/garak/generators/function.py
@@ -16,8 +16,8 @@ class Single(Generator):
     """pass a module#function to be called as generator, with format function(prompt:str, **kwargs)->str"""
 
     uri = "https://github.com/leondz/garak/issues/137"
-
     generator_family_name = "function"
+    supports_multiple_generations = False
 
     def __init__(self, name="", **kwargs):  # name="", generations=self.generations):
         gen_module_name, gen_function_name = name.split("#")
@@ -32,19 +32,17 @@ class Single(Generator):
 
         super().__init__(name, generations=self.generations)
 
-    def generate(self, prompt) -> List[str]:
-        outputs = []
-        for i in range(self.generations):
-            outputs.append(self.generator(prompt, **self.kwargs))
-        return outputs
+    def _call_model(self, prompt: str) -> str:
+        return self.generator(prompt, **self.kwargs)
 
 
 class Multiple(Single):
     """pass a module#function to be called as generator, with format function(prompt:str, generations:int, **kwargs)->List[str]"""
 
-    def generate(self, prompt) -> List[str]:
-        outputs = self.generator(prompt, generations=self.generations, **self.kwargs)
-        return outputs
+    supports_multiple_generations = True
+
+    def _call_model(self, prompt) -> List[str]:
+        return self.generator(prompt, generations=self.generations, **self.kwargs)
 
 
 default_class = "Single"

--- a/garak/generators/ggml.py
+++ b/garak/generators/ggml.py
@@ -28,6 +28,7 @@ class GgmlGenerator(Generator):
     top_k = 40
     top_p = 0.95
     temperature = 0.8
+    exception_on_failure = True
 
     generator_family_name = "ggml"
 
@@ -37,7 +38,7 @@ class GgmlGenerator(Generator):
         self.seed = garak._config.seed
         super().__init__(name, generations=generations)
 
-    def _call_ggml(self, prompt):
+    def _call_model(self, prompt):
         command = [
             self.path_to_ggml_main,
             "-m",
@@ -65,18 +66,14 @@ class GgmlGenerator(Generator):
         if garak._config.args.verbose > 1:
             print("GGML invoked with", command)
         result = subprocess.run(
-            command, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            check=self.exception_on_failure,
         )
         output = result.stdout.decode("utf-8")
         output = re.sub("^" + re.escape(prompt.lstrip()), "", output.lstrip())
         return output
-
-    def generate(self, prompt):
-        outputs = []
-        for g in range(self.generations):
-            output = self._call_ggml(prompt)
-            outputs.append(output)
-        return outputs
 
 
 default_class = "GgmlGenerator"

--- a/garak/generators/langchain.py
+++ b/garak/generators/langchain.py
@@ -58,19 +58,14 @@ class LangChainLLMGenerator(Generator):
 
         self.generator = llm
 
-    def generate(self, prompt):
+    def _call_model(self, prompt: str) -> str:
         """
         Continuation generation method for LangChain LLM integrations.
 
         This calls invoke once per generation; invoke() seems to have the best
         support across LangChain LLM integrations.
         """
-        outputs = []
-        generation_iterator = tqdm.tqdm(list(range(self.generations)), leave=False)
-        generation_iterator.set_description(self.fullname[:55])
-        for i in generation_iterator:
-            outputs.append(self.generator.invoke(prompt))
-        return outputs
+        return self.generator.invoke(prompt)
 
 
 default_class = "LangChainLLMGenerator"

--- a/garak/generators/nemo.py
+++ b/garak/generators/nemo.py
@@ -17,6 +17,7 @@ from garak.generators.base import Generator
 
 
 class NeMoGenerator(Generator):
+    supports_multiple_generations = False
     generator_family_name = "NeMo"
     temperature = 1
     top_p = 1.0
@@ -58,7 +59,7 @@ class NeMoGenerator(Generator):
         (nemollm.error.ServerSideError, nemollm.error.TooManyRequestsError),
         max_value=70,
     )
-    def _call_api(self, prompt):
+    def _call_model(self, prompt):
         # avoid:
         #    doesn't match schema #/components/schemas/CompletionRequestBody: Error at "/prompt": minimum string length is 1
         if prompt == "":
@@ -79,16 +80,6 @@ class NeMoGenerator(Generator):
             length_penalty=1.0,
         )
         return response["text"]
-
-    def generate(self, prompt):
-        outputs = []
-        generation_iterator = tqdm.tqdm(list(range(self.generations)), leave=False)
-        generation_iterator.set_description(
-            self.fullname[:55]
-        )  # replicate names are long incl. hash
-        for i in generation_iterator:
-            outputs.append(self._call_api(prompt))
-        return outputs
 
 
 default_class = "NeMoGenerator"

--- a/garak/generators/test.py
+++ b/garak/generators/test.py
@@ -4,20 +4,24 @@
 These give simple system responses, intended for testing.
 """
 
+from typing import List
+
 from garak.generators.base import Generator
 
 
 class Blank(Generator):
+    supports_multiple_generations = True
     generator_family_name = "Blank"
 
-    def generate(self, prompt):
+    def _call_model(self, prompt: str) -> List[str]:
         return [""] * self.generations
 
 
 class Repeat(Generator):
+    supports_multiple_generations = True
     generator_family_name = "Repeat"
 
-    def generate(self, prompt):
+    def _call_model(self, prompt: str) -> List[str]:
         return [prompt] * self.generations
 
 


### PR DESCRIPTION
Generation management is now all moved up to generators.base.Generator

Model invocation unified / abstracted into _call_model() in all generators

generators.base.Generator.generate now handles parallel requests, which are activated when all of these are true:
* model doesn't support multiple generations (Generator.supports_multiple_generations is false)
* parallel_requests config arg is set and is greater than one