### PR TITLE
add APIConnectionError to openai backoff exception list

### DIFF
--- a/garak/generators/openai.py
+++ b/garak/generators/openai.py
@@ -92,6 +92,7 @@ class OpenAIGenerator(Generator):
             openai.error.ServiceUnavailableError,
             openai.error.APIError,
             openai.error.Timeout,
+            openai.error.APIConnectionError,
         ),
         max_value=70,
     )


### PR DESCRIPTION
openai sometimes returns:

```
  File "/home/leon/anaconda3/envs/garak/lib/python3.11/site-packages/openai/api_requestor.py", line 619, in request_raw
    raise error.APIConnectionError(
openai.error.APIConnectionError: Error communicating with OpenAI: ('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))
```
this now leads garak to back off instead of abort