### PR TITLE
Fixing Exception Cause By Type Error When Scanning LLMs Via Replicate

### DIFF
--- a/garak/cli.py
+++ b/garak/cli.py
@@ -441,8 +441,10 @@ def main(arguments=[]) -> None:
         generator = getattr(generator_mod, generator_class_name)(
             _config.plugins.model_name
         )
-        generator.generations = _config.run.generations
-        generator.seed = _config.run.seed
+        if hasattr(_config.run, "generations") and _config.run.generations is not None:
+            generator.generations = _config.run.generations
+        if hasattr(_config.run, "seed") and _config.run.seed is not None:
+            generator.seed = _config.run.seed
 
         if "generate_autodan" in args and args.generate_autodan:
             from garak.resources.autodan import autodan_generate

--- a/garak/generators/replicate.py
+++ b/garak/generators/replicate.py
@@ -36,7 +36,7 @@ class ReplicateGenerator(Generator):
         self.name = name
         self.fullname = f"{self.generator_family_name} {self.name}"
         self.seed = 9
-        if hasattr(_config.run, "seed"):
+        if hasattr(_config.run, "seed") and _config.run.seed is not None:
             self.seed = _config.run.seed
 
         super().__init__(name, generations=generations)


### PR DESCRIPTION
Hi professor, 

Recently I launched a garak scan using debug mode of vscode with the following configuration: 

        {
            "name": "replicate+meta/llama-2-70b-chat",
            "type": "python",
            "request": "launch",
            "program": "${workspaceFolder}/garak/__main__.py",
            "console": "integratedTerminal",
            "args": [
                "--model_type",
                "replicate",
                "--model_name",
                "meta/llama-2-70b-chat",
                "--probes",
                "malwaregen"
            ],
            "justMyCode": false,
            "env": {
                "REPLICATE_API_TOKEN": "****************************************************************" 
            }
        },
        
But I got exception raised by `....../python3.11/site-packages/backoff/_sync.py:106`:

`input.seed: Invalid type. Expected: integer, given: null`

Finally I found the reason of the exception: 

The value assignment operation of `self.seed = 9` in `garak/generators/replicate.py:38` has been proved invalid according to the collision described below: 

1. `garak/resources/garak.core.yaml:9`: the attribute `seed` has a default value "empty", which is regarded as `None` in Python syntax; 
2. The above `None` value could assign to `self.seed` of class `ReplicateGenerator` by `self.seed = _config.run.seed` in `garak/generators/replicate.py:40` and  `generator.seed = _config.run.seed` in 
`garak/cli.py:445`;
3. `garak/generators/replicate.py:63` needs `self.seed` to be `int` type but it is `None` type.

To address this problem, I made some modifications to avoid value assignment operation when `self.seed` appears to `None` type. I believe those modifications could enhance the robustness of the framework. 

Please review the code comparison for detail. Any problems, feel free to point it out. 😊


