### PR TITLE
Avoid divide by zero error

### DIFF
--- a/garak/report.py
+++ b/garak/report.py
@@ -71,7 +71,7 @@ class Report:
 
         evals_df = pd.DataFrame.from_dict(evals)
         self.evaluations = evals_df.assign(
-            score=lambda x: (x["passed"] / x["total"] * 100)
+            score=lambda x: (x["passed"] / x["total"] * 100) if x["total"] > 0 else 0
         )
         self.scores = self.evaluations[["probe", "score"]].groupby("probe").mean()
         return self


### PR DESCRIPTION
Check that x["total"] > 0 before assigning values, just in case.