### PR TITLE
search in the configs/ subdir for configs (no yaml extension should be given)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9"]
+        python-version: ["3.11"]
 
     steps:
       - uses: actions/checkout@v3

--- a/garak/_config.py
+++ b/garak/_config.py
@@ -133,6 +133,12 @@ def load_config(
         # take config file path as provided
         if os.path.isfile(run_config_filename):
             settings_files.append(run_config_filename)
+        elif os.path.isfile(
+            str(transient.basedir / "configs" / (run_config_filename + ".yaml"))
+        ):
+            settings_files.append(
+                str(transient.basedir / "configs" / (run_config_filename + ".yaml"))
+            )
         else:
             message = f"run config not found: {run_config_filename}"
             logging.error(message)


### PR DESCRIPTION
permit loading default configs directly just `--config fast` instead of having to specify full path to install dir + extension

( fixes #462 )