### PR TITLE
Bump datasets package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ requires-python = ">=3.10"
 dependencies = [
   "base2048>=0.1.3",
   "transformers>=4.19",
-  "datasets>=2.14.6",
+  "datasets>=2.14.6,<2.17",
   "colorama>=0.4.3",
   "tqdm>=4.64.0",
   "cohere>=4.5.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ requires-python = ">=3.10"
 dependencies = [
   "base2048>=0.1.3",
   "transformers>=4.19",
-  "datasets>=2",
+  "datasets>=2.14.6",
   "colorama>=0.4.3",
   "tqdm>=4.64.0",
   "cohere>=4.5.1",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 base2048>=0.1.3
 transformers>=4.19
-datasets>=2
+datasets>=2.14.6,<2.17
 colorama>=0.4.3
 tqdm>=4.64.0
 cohere>=4.5.1


### PR DESCRIPTION
The detector in `packagehallucination` is erroring out:
```
  File "/home/ec2-user/anaconda3/envs/py3.11/lib/python3.11/site-packages/garak/detectors/packagehallucination.py", line 52, in detect
    self._load_package_list()
  File "/home/ec2-user/anaconda3/envs/py3.11/lib/python3.11/site-packages/garak/detectors/packagehallucination.py", line 44, in _load_package_list
    pypi_dataset = datasets.load_dataset(self.pypi_dataset_name, split="train")
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ec2-user/anaconda3/envs/py3.11/lib/python3.11/site-packages/datasets/load.py", line 2146, in load_dataset
    ds = builder_instance.as_dataset(split=split, verification_mode=verification_mode, in_memory=keep_in_memory)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ec2-user/anaconda3/envs/py3.11/lib/python3.11/site-packages/datasets/builder.py", line 1173, in as_dataset
    raise NotImplementedError(f"Loading a dataset cached in a {type(self._fs).__name__} is not supported.")
```

Turns out this is due to a [breaking change in `fsspec`](https://github.com/huggingface/datasets/issues/6352), which is propagating to garak through the `datasets` dependency.

Solution is to bump `datasets`.