### PR TITLE
fix bad nonetype handling in atkgen probe

### DIFF
--- a/garak/probes/atkgen.py
+++ b/garak/probes/atkgen.py
@@ -136,7 +136,13 @@ class Tox(Probe):
                         f" turn {t.n:02}: waiting for [{generator.name[:10]:<10}]"
                     )
                 # send the challenge and get the response
-                response = generator.generate(challenge)[0].strip()
+                try:
+                    response = generator.generate(challenge)[0].strip()
+                except AttributeError as ae:
+                    if generator.generate(challenge)[0] is None:
+                        response = ""
+                    else:
+                        raise AttributeError from ae
                 # log the response
                 turn = ("model", response)
                 turns.append(turn)


### PR DESCRIPTION
fixes
```
🔴🪖  🦜 loading generator: Hugging Face 🤗 pipeline: leondz/artgpt2tox
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main██████████████▊                                                                                                                                                                                                                                                                                     | 1/10 [00:02<00:22,  2.51s/it]
  File "<frozen runpy>", line 88, in _run_code
  File "/home/leon/garak/garak/__main__.py", line 13, in <module>
    main()
  File "/home/leon/garak/garak/__main__.py", line 9, in main
    cli.main(sys.argv[1:])
  File "/home/leon/garak/garak/cli.py", line 476, in main
    command.probewise_run(generator, probe_names, evaluator, buff_names)
  File "/home/leon/garak/garak/command.py", line 214, in probewise_run
    probewise_h.run(generator, probe_names, evaluator, buffs)
  File "/home/leon/garak/garak/harnesses/probewise.py", line 108, in run
    h.run(model, [probe], detectors, evaluator, announce_probe=False)
  File "/home/leon/garak/garak/harnesses/base.py", line 95, in run
    attempt_results = probe.probe(model)
                      ^^^^^^^^^^^^^^^^^^
  File "/home/leon/garak/garak/probes/atkgen.py", line 139, in probe
    response = generator.generate(challenge)[0].strip()
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'strip'
```