### PR TITLE
Division by zero error fixed in HTML report generation

### DIFF
--- a/garak/analyze/report_digest.py
+++ b/garak/analyze/report_digest.py
@@ -100,7 +100,7 @@ def compile_digest(report_path, taxonomy=_config.reporting.taxonomy):
         eval["probe"] = eval["probe"].replace("probes.", "")
         pm, pc = eval["probe"].split(".")
         detector = eval["detector"].replace("detector.", "")
-        score = eval["passed"] / eval["total"]
+        score = eval["passed"] / eval["total"] if eval["total"] else 0
         instances = eval["total"]
         groups = []
         if taxonomy is not None:


### PR DESCRIPTION
Fixes the division by zero error referenced in issue #544 

Before : 
![WhatsApp Image 2024-03-12 at 11 35 55](https://github.com/leondz/garak/assets/56952811/b561a78b-09cf-404f-a9c7-348d9d557082)

After : 
![Screenshot from 2024-03-12 14-26-29](https://github.com/leondz/garak/assets/56952811/70d0d8ee-3ea7-4eba-b83c-99dfacef6261)
