### PR TITLE
Add additional error message when __doc__ is None type

### DIFF
--- a/garak/detectors/base.py
+++ b/garak/detectors/base.py
@@ -28,7 +28,13 @@ class Detector:
 
     def _set_description(self):
         if "description" not in dir(self):
-            self.description = self.__doc__.split("\n")[0]
+            try:
+                self.description = self.__doc__.split("\n")[0]
+            except AttributeError as ae:
+                err_msg: str = f"Documentation string of class {self.detectorname} is unavailable, \
+                    see https://docs.python.org/3.11/reference/datamodel.html#function.__doc__:~:text=function.__doc__-,The%20function%E2%80%99s%20documentation%20string,-%2C%20or%20None%20if"
+                logging.warning(err_msg)
+                raise ValueError(err_msg)
 
     def __init__(self):
         if "name" not in dir(self):


### PR DESCRIPTION
When developing a new detector, people may forget to write documentation string for the specific Python class. This will cause Exception which is relatively hard to locate the bad line.

In my case, garak told me detector load failed when developing a new prompt-based adversarial attack probe and detector pair.

![e086944c33a8be5534cfac091c9e09c](https://github.com/leondz/garak/assets/35065046/c36c2ab1-dd01-4cf4-a557-d68a62b7d16c)

In the end, I found the missing of documentation string of new PromptAttack class cause this exception.

![a19bc4f6af64a3a9dfaa3ee7a4da5cf](https://github.com/leondz/garak/assets/35065046/1350048e-b6c7-4c18-aa4d-aefc6f61cba5)

To better develop experience, I add some error handle code there. See file changes for detail.