### PR TITLE
skip `verbose` flag in secondary parser

### DIFF
--- a/garak/cli.py
+++ b/garak/cli.py
@@ -264,6 +264,9 @@ def main(arguments=[]) -> None:
                 arg_names[raw_option_string] = action.option_strings
 
     for arg, val in vars(args).items():
+        if arg == 'verbose':
+            # the 'verbose' flag is currently unique and retrieved from `args` directly
+            continue
         if isinstance(val, bool):
             if val:
                 aux_parser.add_argument(*arg_names[arg], action="store_true")


### PR DESCRIPTION
When parsing the command line options on the CLI the `verbose` flag count is already treated uniquely. This change removes `verbose` from the `aux_parser` to avoid inconsistent `action` expectations.

Prior to this change when walking the options `verbose` would be registered or `aux_parser` with the default action `store` causing the Argparser to expect an value to be provided during parsing.

Using the exampled gpt-2 command can validate this change:
Existing:
```
% python3 -m garak -v --model_type huggingface --model_name gpt2 --probes dan.Dan_11_0
garak LLM security probe v0.9.0.12.post1 ( https://github.com/leondz/garak ) at 2024-03-25T14:29:12.154243
usage: __main__.py [-h] [--verbose VERBOSE] [--report_prefix REPORT_PREFIX] [--narrow_output] [--parallel_requests] [--parallel_attempts] [--seed SEED] [--deprefix]
                   [--eval_threshold EVAL_THRESHOLD] [--generations GENERATIONS] [--config CONFIG] [--model_type MODEL_TYPE] [--model_name MODEL_NAME]
                   [--generator_option_file GENERATOR_OPTION_FILE] [--generator_options GENERATOR_OPTIONS] [--probes PROBES] [--probe_option_file PROBE_OPTION_FILE]
                   [--probe_options PROBE_OPTIONS] [--probe_tags PROBE_TAGS] [--detectors DETECTORS] [--extended_detectors] [--buffs BUFFS] [--taxonomy TAXONOMY]
                   [--plugin_info PLUGIN_INFO] [--list_probes] [--list_detectors] [--list_generators] [--list_buffs] [--list_config] [--version] [--report REPORT]
                   [--interactive] [--generate_autodan] [--interactive.py]
__main__.py: error: argument --verbose/-v: expected one argument
```

Patched:
```
% python3 -m garak -v --model_type huggingface --model_name gpt2 --probes dan.Dan_11_0
garak LLM security probe v0.9.0.12.post1 ( https://github.com/leondz/garak ) at 2024-03-25T14:28:43.975393
📜 reporting to garak_runs/garak.074fe0ab-e113-42de-ab29-180e2547a0a4.report.jsonl
🦜 loading generator: Hugging Face 🤗 pipeline: gpt2
🕵️  queue of probes: dan.Dan_11_0
loading probe: garak.probes.dan.Dan_11_0
loading detector: garak.detectors.dan.DAN
loading detector: garak.detectors.mitigation.MitigationBypass
probes.dan.Dan_11_0:   0%|                                                                                                                           | 0/1 [00:00<?, ?it/s]This is a friendly reminder - the current text generation call will exceed the model's predefined maximum length (1024). Depending on the model, you may observe exceptions, performance degradation, or nothing at all.
dan.Dan_11_0                                                                                 dan.DAN: SKIP  ok on    0/   0
dan.Dan_11_0                                                             mitigation.MitigationBypass: SKIP  ok on    0/   0
📜 report closed :) garak_runs/garak.074fe0ab-e113-42de-ab29-180e2547a0a4.report.jsonl
📜 report html summary being written to garak_runs/garak.074fe0ab-e113-42de-ab29-180e2547a0a4.report.html
loading probe: garak.probes.dan.Dan_11_0
loading detector: garak.detectors.dan.DAN
loading detector: garak.detectors.mitigation.MitigationBypass
✔️  garak run complete in 11.93s
```
