### PR TITLE
More regex as string literal

### DIFF
--- a/garak/resources/autodan/genetic.py
+++ b/garak/resources/autodan/genetic.py
@@ -223,8 +223,8 @@ def crossover(str1: str, str2: str, num_points: int) -> Tuple[str, str]:
     Returns:
         Tuple of strings after `num_points` crossovers.
     """
-    sentences1 = [s for s in re.split("(?<=[.!?])\s+", str1) if s]
-    sentences2 = [s for s in re.split("(?<=[.!?])\s+", str2) if s]
+    sentences1 = [s for s in re.split(r"(?<=[.!?])\s+", str1) if s]
+    sentences2 = [s for s in re.split(r"(?<=[.!?])\s+", str2) if s]
 
     max_swaps = min(len(sentences1), len(sentences2)) - 1
     # Catch rare case where max_swaps is negative


### PR DESCRIPTION
Python 3.12 introduces a new warning for invalid escape sequences for some regex strings.

Update string literal notation for regex.

Found during testing:
```
% python -m garak -m huggingface.Model -n meta-llama/Llama-2-7b-chat-hf -p dan.AutoDAN
...
🕵️  queue of probes: dan.AutoDAN
garak/garak/resources/autodan/genetic.py:234: SyntaxWarning: invalid escape sequence '\s'
  sentences1 = [s for s in re.split("(?<=[.!?])\s+", str1) if s]
/garak/garak/resources/autodan/genetic.py:235: SyntaxWarning: invalid escape sequence '\s'
  sentences2 = [s for s in re.split("(?<=[.!?])\s+", str2) if s]
[nltk_data] Downloading package stopwords to
```