### PR TITLE
allow configuration of HF generators from YAML / global config

### DIFF
--- a/garak/generators/huggingface.py
+++ b/garak/generators/huggingface.py
@@ -48,7 +48,6 @@ class HFConfigurable:
     def _load_hf_config(self):
         if "huggingface" in _config.plugins.generators:
             generator_classname = self.__class__.__name__
-            print(generator_classname)
             if generator_classname in _config.plugins.generators["huggingface"]:
                 for k, v in _config.plugins.generators["huggingface"][
                     generator_classname


### PR DESCRIPTION
see #589 

Hugging Face generators now take params from global config

e.g. 

```
(garak) 11:54:18 x1:~/dev_ext/garak [feature/hf_config] $ cat garak/garak.site.yaml 
plugins:
  generators:
    huggingface:
      Pipeline:
        dtype: bfloat16
(garak) 11:30:42 x1:~/dev_ext/garak [feature/hf_config] $ python3
Python 3.12.1 | packaged by Anaconda, Inc. | (main, Jan 19 2024, 15:51:05) [GCC 11.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import garak
>>> import garak.generators.huggingface
>>> p = garak.generators.huggingface.Pipeline("gpt2")
🦜 loading generator: Hugging Face 🤗 pipeline: gpt2
>>> p.dtype
'bfloat16'
```