### PR TITLE
Enforce warning output for `garak` classes.

### DIFF
--- a/garak/_config.py
+++ b/garak/_config.py
@@ -97,9 +97,10 @@ def _load_yaml_config(settings_filenames) -> dict:
     config_files += settings_filenames
     config = {}
     for settings_filename in settings_filenames:
-        settings = yaml.safe_load(open(settings_filename, encoding="utf-8"))
-        if settings is not None:
-            config = _combine_into(settings, config)
+        with open(settings_filename, encoding="utf-8") as settings_file:
+            settings = yaml.safe_load(settings_file)
+            if settings is not None:
+                config = _combine_into(settings, config)
     return config
 
 

--- a/garak/probes/misleading.py
+++ b/garak/probes/misleading.py
@@ -43,17 +43,18 @@ class FalseAssertion50(Probe):
         self.prompts = []
 
         for prefix in prefixes:
-            for false_assertion in open(
+            with open(
                 _config.transient.basedir / "resources/truefalse_falseclaims_50.txt",
                 "r",
                 encoding="utf-8",
-            ):
-                false_assertion = false_assertion.strip()
-                if not false_assertion:
-                    continue
-                if not prefix:
-                    self.prompts.append(false_assertion)
-                else:
-                    if false_assertion.startswith("The"):
-                        false_assertion = "t" + false_assertion[1:]
-                    self.prompts.append(f"{prefix} {false_assertion}")
+            ) as assertions:
+                for false_assertion in assertions:
+                    false_assertion = false_assertion.strip()
+                    if not false_assertion:
+                        continue
+                    if not prefix:
+                        self.prompts.append(false_assertion)
+                    else:
+                        if false_assertion.startswith("The"):
+                            false_assertion = "t" + false_assertion[1:]
+                        self.prompts.append(f"{prefix} {false_assertion}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,3 +80,9 @@ packages = ["garak"]
 line-length = 88
 target-version = ['py310', 'py311', 'py312']
 include = '\.pyi?$'
+
+[tool.pytest.ini_options]
+filterwarnings = [
+    "ignore",
+    "default:::garak",
+]

--- a/tests/buffs/test_buff_config.py
+++ b/tests/buffs/test_buff_config.py
@@ -85,11 +85,15 @@ def cleanup(request):
     """Cleanup a testing directory once we are finished."""
 
     def remove_buff_reports():
-        os.remove(f"{prefix}.report.jsonl")
-        try:
-            os.remove(f"{prefix}.report.html")
-            os.remove(f"{prefix}.hitlog.jsonl")
-        except FileNotFoundError:
-            pass
+        files = [
+            f"{prefix}.report.jsonl",
+            f"{prefix}.report.html",
+            f"{prefix}.hitlog.jsonl",
+        ]
+        for file in files:
+            try:
+                os.remove(file)
+            except FileNotFoundError:
+                pass
 
     request.addfinalizer(remove_buff_reports)

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1,10 +1,20 @@
 #!/usr/bin/env python3
 
 import re
+import pytest
+import os
 
-from garak import __version__, cli
+from garak import __version__, cli, _config
 
 ansi_escape = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
+
+
+@pytest.fixture(autouse=True)
+def close_report_file():
+    if _config.transient.reportfile is not None:
+        _config.transient.reportfile.close()
+        if os.path.exists(_config.transient.report_filename):
+            os.remove(_config.transient.report_filename)
 
 
 def test_version_command(capsys):


### PR DESCRIPTION
Introduction of the `litellm` package caused test runs to report warnings about pending deprecations in dependency code not directly in scope of this project.

This change raises lib warnings more clearly and has an effect of suppressing warnings from dependency classes. While not optimal, the explicit check for warnings from repo code is a reasonable trade off.

A separate maintenance action should be added in a future iteration to add checks for warnings introduced when updating dependency versions.

The changes to lib files resolve warnings primarily related file handles that are opened and never closed. Changes to the tests may be be worth an extended look as most are related to not closing the `_config.TransientConfig.reportfile` when the object is reloaded or goes out of scope.
