### PR TITLE
Remove `#!` entries from files not intended as executables

### DIFF
--- a/garak/_plugins.py
+++ b/garak/_plugins.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # SPDX-FileCopyrightText: Portions Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/garak/analyze/aggregate_reports.py
+++ b/garak/analyze/aggregate_reports.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # SPDX-FileCopyrightText: Portions Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/garak/analyze/analyze_log.py
+++ b/garak/analyze/analyze_log.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import sys
 import json
 

--- a/garak/analyze/count_tokens.py
+++ b/garak/analyze/count_tokens.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/garak/analyze/misp.py
+++ b/garak/analyze/misp.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # report probes per tag
 # look for untagged probes
 # look for tags without description entries

--- a/garak/buffs/base.py
+++ b/garak/buffs/base.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/garak/buffs/encoding.py
+++ b/garak/buffs/encoding.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/garak/buffs/low_resource_languages.py
+++ b/garak/buffs/low_resource_languages.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/garak/buffs/lowercase.py
+++ b/garak/buffs/lowercase.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/garak/buffs/paraphrase.py
+++ b/garak/buffs/paraphrase.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/garak/command.py
+++ b/garak/command.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # SPDX-FileCopyrightText: Portions Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/garak/detectors/replay.py
+++ b/garak/detectors/replay.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # SPDX-FileCopyrightText: Portions Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/garak/generators/guardrails.py
+++ b/garak/generators/guardrails.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/garak/generators/langchain.py
+++ b/garak/generators/langchain.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # SPDX-FileCopyrightText: Portions Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/garak/generators/nemo.py
+++ b/garak/generators/nemo.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/garak/generators/nvcf.py
+++ b/garak/generators/nvcf.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/garak/generators/octo.py
+++ b/garak/generators/octo.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/garak/generators/openai_v0.py
+++ b/garak/generators/openai_v0.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/garak/generators/rasa.py
+++ b/garak/generators/rasa.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/garak/generators/rest.py
+++ b/garak/generators/rest.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/garak/harnesses/base.py
+++ b/garak/harnesses/base.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # SPDX-FileCopyrightText: Portions Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/garak/harnesses/probewise.py
+++ b/garak/harnesses/probewise.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # SPDX-FileCopyrightText: Portions Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/garak/harnesses/pxd.py
+++ b/garak/harnesses/pxd.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # SPDX-FileCopyrightText: Portions Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/garak/probes/base.py
+++ b/garak/probes/base.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # SPDX-FileCopyrightText: Portions Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/garak/probes/dan.py
+++ b/garak/probes/dan.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # SPDX-FileCopyrightText: Portions Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/garak/probes/gcg.py
+++ b/garak/probes/gcg.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # SPDX-FileCopyrightText: Portions Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 """GCG probes.

--- a/garak/probes/replay.py
+++ b/garak/probes/replay.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # SPDX-FileCopyrightText: Portions Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/garak/probes/tap.py
+++ b/garak/probes/tap.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # SPDX-FileCopyrightText: Portions Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/garak/resources/autodan/autodan.py
+++ b/garak/resources/autodan/autodan.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import argparse
 from logging import getLogger
 import os

--- a/garak/resources/rest/restserv.py
+++ b/garak/resources/rest/restserv.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/garak/resources/tap/__init__.py
+++ b/garak/resources/tap/__init__.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/analyze/test_analyze.py
+++ b/tests/analyze/test_analyze.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/buffs/test_buff_config.py
+++ b/tests/buffs/test_buff_config.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import re
 import pytest
 import os

--- a/tests/detectors/test_detectors_packagehallucination.py
+++ b/tests/detectors/test_detectors_packagehallucination.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 from garak.attempt import Attempt
 import garak.detectors.base
 import garak.detectors.packagehallucination

--- a/tests/generators/test_huggingface.py
+++ b/tests/generators/test_huggingface.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import transformers
 import garak.generators.huggingface
 

--- a/tests/generators/test_openai.py
+++ b/tests/generators/test_openai.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/plugins/test_plugin_load.py
+++ b/tests/plugins/test_plugin_load.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import pytest
 
 import garak

--- a/tests/probes/test_probe_docs.py
+++ b/tests/probes/test_probe_docs.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/probes/test_probe_format.py
+++ b/tests/probes/test_probe_format.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import importlib
 import pytest
 

--- a/tests/probes/test_probe_tags.py
+++ b/tests/probes/test_probe_tags.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/probes/test_probes_encoding.py
+++ b/tests/probes/test_probes_encoding.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import garak.probes.encoding
 
 

--- a/tests/probes/test_probes_packagehallucination.py
+++ b/tests/probes/test_probes_packagehallucination.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import garak.probes.packagehallucination
 
 

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import importlib
 import os
 from pathlib import Path

--- a/tests/test_reqs.py
+++ b/tests/test_reqs.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 


### PR DESCRIPTION
General code hygiene cleanup.

[#!](https://en.wikipedia.org/wiki/Shebang_(Unix)) entires are meant as instruction to the shell about what interpreter to invoke for execution.

Original inclusion was around clarification that the tool is only compatible with `python3`. This is now clarified in the pyproject.toml.