### PR TITLE
update avidtools to remove typing reference

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
   "jinja2>=3.1.2",
   "nltk>=3.8.1",
   "accelerate>=0.23.0",
-  "avidtools==0.1.1.2",
+  "avidtools==0.1.2",
   "stdlibs>=2022.10.9",
   "langchain>=0.0.300",
   "nemollm>=0.3.0",
@@ -59,7 +59,6 @@ dependencies = [
   "deepl==1.17.0",
   "fschat>=0.2.36",
   "litellm>=1.33.8",
-  "typing>=3.7,<3.8; python_version<'3.5'",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ rapidfuzz>=3.0.0
 jinja2>=3.1.2
 nltk>=3.8.1
 accelerate>=0.23.0
-avidtools==0.1.1.2
+avidtools==0.1.2
 stdlibs>=2022.10.9
 langchain>=0.0.300
 nemollm>=0.3.0
@@ -27,7 +27,6 @@ ecoji>=0.1.0
 deepl==1.17.0
 fschat>=0.2.36
 litellm>=1.33.8
-typing>=3.7,<3.8; python_version<'3.5'
 # tests
 pytest>=8.0
 requests-mock==1.12.1


### PR DESCRIPTION
* Update to latest released version of [avidtools](https://github.com/avidml/avidtools)

This removes the explicit install requirement for `typing` that is now included as a default distributed package with python 3.5+