### PR TITLE
meta the arguments a bit for GET vs other request types

### DIFF
--- a/garak/resources/rest/restdemo.json
+++ b/garak/resources/rest/restdemo.json
@@ -1,13 +1,15 @@
 {
-    "name": "example service",
-    "uri": "https://localhost:37176/endpoint",
-    "method": "post",
-    "headers":{
-        "X-Authorization": "$KEY",
-    },
-    "req_template_json_object":{
-        "text":"$INPUT"
-    },
-    "response_json": true,
-    "response_json_field": "text"
+    "rest.RestGenerator": {
+        "name": "example service",
+        "uri": "http://localhost:37176/endpoint",
+        "method": "post",
+        "headers":{
+            "X-Authorization": "$KEY"
+        },
+        "req_template_json_object":{
+            "text":"$INPUT"
+        },
+        "response_json": true,
+        "response_json_field": "text"
+    }
 }


### PR DESCRIPTION
Fix #557

Tested example:
```
REST_API_KEY="fake" ./garak_debug.py -m rest --generator_option_file garak/resources/rest/restdemo.json -p encoding.InjectBase16
```

Changing `restdemo.json` method types using `garak/resources/rest/restserv.py` as server side:
`post`:
```
127.0.0.1 - - [29/Apr/2024 15:53:55] "POST /endpoint HTTP/1.1" 200 -
values CombinedMultiDict([ImmutableMultiDict([]), ImmutableMultiDict([])])
data b'{"text": "32373561303231626266623634383965353464343731383939663764623964313636336663363935656332666532613263343533386161626636353166643066"}'
headers Host: localhost:37176
User-Agent: python-requests/2.31.0
Accept-Encoding: gzip, deflate
Accept: */*
Connection: keep-alive
X-Authorization: fake
Content-Length: 140
```

`get`:
```
127.0.0.1 - - [29/Apr/2024 15:54:19] "GET /endpoint?{"text":%20"32373561303231626266623634383965353464343731383939663764623964313636336663363935656332666532613263343533386161626636353166643066"} HTTP/1.1" 200 -
values CombinedMultiDict([ImmutableMultiDict([]), ImmutableMultiDict([])])
data b'{"text": "32373561303231626266623634383965353464343731383939663764623964313636336663363935656332666532613263343533386161626636353166643066"}'
headers Host: localhost:37176
User-Agent: python-requests/2.31.0
Accept-Encoding: gzip, deflate
Accept: */*
Connection: keep-alive
X-Authorization: fake
Content-Length: 140
```

This probably deserves better testing at some point.