### PR TITLE
Enable parallel OpenAI calls

### DIFF
--- a/docs/source/garak.probes.base.rst
+++ b/docs/source/garak.probes.base.rst
@@ -15,7 +15,7 @@ The general flow in ``probe()`` is:
   * Create a list of ``attempt`` objects corresponding to the prompts in the probe, using ``_mint_attempt()``. Prompts are iterated through and passed to ``_mint_attempt()``. The ``_mint_attempt()`` function works by converting a prompt to a full ``attempt`` object, and then passing that ``attempt`` object through ``_attempt_prestore_hook()``. The result is added to a list in ``probe()`` called ``attempts_todo``.
   * If any buffs are loaded, the list of attempts is passed to ``_buff_hook()`` for transformation. ``_buff_hook()`` checks the config and then creates a new attempt list, ``buffed_attempts``, which contains the results of passing each original attempt through each instantiated buff in turn. Instantiated buffs are tracked in ``_config.buffmanager.buffs``. Once ``buffed_attempts`` is populated, it's returned, and overwrites ``probe()``'s ``attempts_todo``.
   * At this point, ``probe()`` is ready to start interacting with the generator. An empty list ``attempts_completed`` is set up to hold completed results.
-  * If configured, parallelisation of attempt processing is set up using ``multiprocessing``. The relevant config variable is ``_config.system.parallel_attempts`` and the value should be greater than 1 (1 in parallel is just serial).
+  * The set of attempts is then passed to ``_execute_all``.
   * Attempts are iterated through (ether in parallel or serial) and individually posed to the generator using ``_execute_attempt()``.
   * The process of putting one ``attempt`` through the generator is orchestrated by ``_execute_attempt()``, and runs as follows:
 
@@ -33,15 +33,20 @@ The general flow in ``probe()`` is:
 
 4. **_buff_hook()**. Called from ``probe()`` to buff attempts after the list in ``attempts_todo`` is populated. 
 
-5. **_execute_attempt()**. Called from ``probe()`` to orchestrate processing of one attempt by the generator.
+5. **_execute_attempt()**. Called from ``_execute_all()`` to orchestrate processing of one attempt by the generator. 
 
-6. **_generator_precall_hook()**. Called at the start of ``_execute_attempt()`` with attempt and generator. Can be used to e.g. adjust generator parameters.
+6. **_execute_all()**. Called from ``probe()`` to orchestrate processing of the set of attempts by the generator.
 
-7. **_mint_attempt()**. Converts a prompt to a new attempt object, managing metadata like attempt status and probe classname.
+  * If configured, parallelisation of attempt processing is set up using ``multiprocessing``. The relevant config variable is ``_config.system.parallel_attempts`` and the value should be greater than 1 (1 in parallel is just serial).
+  * Attempts are iterated through (ether in parallel or serial) and individually posed to the generator using ``_execute_attempt()``.
 
-8. **_postprocess_buff()**. Called in ``_execute_attempt()`` after results come back from the generator, if a buff specifies it. Used to e.g. translate results back if already translated to another language.
+7. **_generator_precall_hook()**. Called at the start of ``_execute_attempt()`` with attempt and generator. Can be used to e.g. adjust generator parameters.
 
-9. **_postprocess_hook()**. Called near the end of ``_execute_attempt()`` to apply final postprocessing to attempts after generation. Can be used to restore state, e.g. if generator parameters were adjusted, or to clean up generator output.
+8. **_mint_attempt()**. Converts a prompt to a new attempt object, managing metadata like attempt status and probe classname.
+
+9. **_postprocess_buff()**. Called in ``_execute_attempt()`` after results come back from the generator, if a buff specifies it. Used to e.g. translate results back if already translated to another language.
+
+10. **_postprocess_hook()**. Called near the end of ``_execute_attempt()`` to apply final postprocessing to attempts after generation. Can be used to restore state, e.g. if generator parameters were adjusted, or to clean up generator output.
 
 
 .. automodule:: garak.probes.base

--- a/garak/generators/openai.py
+++ b/garak/generators/openai.py
@@ -1,9 +1,9 @@
-"""OpenAI API generator
+"""OpenAI API Compatible generators
 
-Supports chat + chatcompletion models. Put your OpenAI API key in
-an environment variable called OPENAI_API_KEY. Put the name of the
+Supports chat + chatcompletion models. Put your API key in
+an environment variable documented in the selected generator. Put the name of the
 model you want in either the --model_name command line parameter, or
-pass it as an argument to the OpenAIGenerator constructor.
+pass it as an argument to the Generator constructor.
 
 sources:
 * https://platform.openai.com/docs/models/model-endpoint-compatibility
@@ -82,29 +82,40 @@ context_lengths = {
 }
 
 
-class OpenAIGenerator(Generator):
-    """Generator wrapper for OpenAI text2text models. Expects API key in the OPENAI_API_KEY environment variable"""
+class OpenAICompatible(Generator):
+    """Generator base class for OpenAI compatible text2text restful API. Implements shared initialization and execution methods."""
+
+    ENV_VAR = "OpenAICompatible_API_KEY".upper()  # Placeholder override when extending
 
     supports_multiple_generations = True
-    generator_family_name = "OpenAI"
+    generator_family_name = "OpenAICompatible"  # Placeholder override when extending
 
+    # template defaults optionally override when extending
     temperature = 0.7
     top_p = 1.0
     frequency_penalty = 0.0
     presence_penalty = 0.0
     stop = ["#", ";"]
 
+    def _load_client(self):
+        # Required stub implemented when extending `OpenAICompatible`
+        raise NotImplementedError
+
+    def _clear_client(self):
+        # Required stub implemented when extending `OpenAICompatible`
+        raise NotImplementedError
+
     def __init__(self, name, generations=10):
         self.name = name
-        self.fullname = f"OpenAI {self.name}"
+        self.fullname = f"{self.generator_family_name} {self.name}"
 
         super().__init__(name, generations=generations)
 
-        self.api_key = os.getenv("OPENAI_API_KEY", default=None)
+        self.api_key = os.getenv(self.ENV_VAR, default=None)
         if self.api_key is None:
             raise ValueError(
-                'Put the OpenAI API key in the OPENAI_API_KEY environment variable (this was empty)\n \
-                e.g.: export OPENAI_API_KEY="sk-123Xgenerators/openai.pyXXXXXXXXXXX"'
+                f'Put the {self.generator_family_name} API key in the {self.ENV_VAR} environment variable (this was empty)\n \
+                e.g.: export {self.ENV_VAR}="sk-123Xgenerators/openai.pyXXXXXXXXXXX"'
             )
 
         self._load_client()
@@ -115,7 +126,7 @@ class OpenAIGenerator(Generator):
         elif self.name == "":
             openai_model_list = sorted([m.id for m in self.client.models.list().data])
             raise ValueError(
-                "Model name is required for OpenAI, use --model_name\n"
+                f"Model name is required for {self.generator_family_name}, use --model_name\n"
                 + "  API returns following available models: ▶️   "
                 + "  ".join(openai_model_list)
                 + "\n"
@@ -123,26 +134,10 @@ class OpenAIGenerator(Generator):
             )
         else:
             raise ValueError(
-                f"No OpenAI API defined for '{self.name}' in generators/openai.py - please add one!"
+                f"No {self.generator_family_name} API defined for '{self.name}' in generators/openai.py - please add one!"
             )
         # clear client config to enable object to `pickle`
         self._clear_client()
-
-    def _load_client(self):
-        self.client = openai.OpenAI(api_key=self.api_key)
-
-        if self.name in completion_models:
-            self.generator = self.client.completions
-        elif self.name in chat_models:
-            self.generator = self.client.chat.completions
-        elif "-".join(self.name.split("-")[:-1]) in chat_models and re.match(
-            r"^.+-[01][0-9][0-3][0-9]$", self.name
-        ):  # handle model names -MMDDish suffix
-            self.generator = self.client.completions
-
-    def _clear_client(self):
-        self.generator = None
-        self.client = None
 
     # noinspection PyArgumentList
     @backoff.on_exception(
@@ -165,7 +160,7 @@ class OpenAIGenerator(Generator):
         if self.generator == self.client.completions:
             if not isinstance(prompt, str):
                 msg = (
-                    f"Expected a string for OpenAI completions model {self.name}, but got {type(prompt)}. "
+                    f"Expected a string for {self.generator_family_name} completions model {self.name}, but got {type(prompt)}. "
                     f"Returning nothing!"
                 )
                 logging.error(msg)
@@ -192,7 +187,7 @@ class OpenAIGenerator(Generator):
                 messages = prompt
             else:
                 msg = (
-                    f"Expected a list of dicts for OpenAI Chat model {self.name}, but got {type(prompt)} instead. "
+                    f"Expected a list of dicts for {self.generator_family_name} Chat model {self.name}, but got {type(prompt)} instead. "
                     f"Returning nothing!"
                 )
                 logging.error(msg)
@@ -215,6 +210,29 @@ class OpenAIGenerator(Generator):
             raise ValueError(
                 "Unsupported model at generation time in generators/openai.py - please add a clause!"
             )
+
+
+class OpenAIGenerator(OpenAICompatible):
+    """Generator wrapper for OpenAI text2text models. Expects API key in the OPENAI_API_KEY environment variable"""
+
+    ENV_VAR = "OPENAI_API_KEY"
+    generator_family_name = "OpenAI"
+
+    def _load_client(self):
+        self.client = openai.OpenAI(api_key=self.api_key)
+
+        if self.name in completion_models:
+            self.generator = self.client.completions
+        elif self.name in chat_models:
+            self.generator = self.client.chat.completions
+        elif "-".join(self.name.split("-")[:-1]) in chat_models and re.match(
+            r"^.+-[01][0-9][0-3][0-9]$", self.name
+        ):  # handle model names -MMDDish suffix
+            self.generator = self.client.completions
+
+    def _clear_client(self):
+        self.generator = None
+        self.client = None
 
 
 default_class = "OpenAIGenerator"

--- a/garak/generators/openai.py
+++ b/garak/generators/openai.py
@@ -125,9 +125,9 @@ class OpenAIGenerator(Generator):
             raise ValueError(
                 f"No OpenAI API defined for '{self.name}' in generators/openai.py - please add one!"
             )
+        # clear client config to enable object to `pickle`
         self._clear_client()
 
-    # this could also be __setstate__
     def _load_client(self):
         self.client = openai.OpenAI(api_key=self.api_key)
 
@@ -140,7 +140,6 @@ class OpenAIGenerator(Generator):
         ):  # handle model names -MMDDish suffix
             self.generator = self.client.completions
 
-    # this could also just be __getstate__
     def _clear_client(self):
         self.generator = None
         self.client = None
@@ -161,6 +160,7 @@ class OpenAIGenerator(Generator):
         self, prompt: Union[str, list[dict]], generations_this_call: int = 1
     ) -> List[str]:
         if self.client is None:
+            # reload client once when consuming the generator
             self._load_client()
         if self.generator == self.client.completions:
             if not isinstance(prompt, str):

--- a/garak/generators/openai.py
+++ b/garak/generators/openai.py
@@ -115,7 +115,7 @@ class OpenAICompatible(Generator):
         if self.api_key is None:
             raise ValueError(
                 f'Put the {self.generator_family_name} API key in the {self.ENV_VAR} environment variable (this was empty)\n \
-                e.g.: export {self.ENV_VAR}="sk-123Xgenerators/openai.pyXXXXXXXXXXX"'
+                e.g.: export {self.ENV_VAR}="sk-123XXXXXXXXXXXX"'
             )
 
         self._load_client()

--- a/garak/probes/base.py
+++ b/garak/probes/base.py
@@ -139,9 +139,44 @@ class Probe:
         if self.post_buff_hook:
             this_attempt = self._postprocess_buff(this_attempt)
         this_attempt = self._postprocess_hook(this_attempt)
-        _config.transient.reportfile.write(json.dumps(this_attempt.as_dict()) + "\n")
+        # access to this file should be single threaded, this may need to be adjusted as a logger
         self._generator_cleanup()
         return copy.deepcopy(this_attempt)
+
+    def _execute_all(self, attempts) -> Iterable[garak.attempt.Attempt]:
+        attempts_completed: Iterable[garak.attempt.Attempt] = []
+
+        if (
+            _config.system.parallel_attempts
+            and _config.system.parallel_attempts > 1
+            and self.parallelisable_attempts
+            and len(attempts) > 1
+        ):
+            from multiprocessing import Pool
+
+            attempt_bar = tqdm.tqdm(total=len(attempts), leave=False)
+            attempt_bar.set_description(self.probename.replace("garak.", ""))
+
+            with Pool(_config.system.parallel_attempts) as attempt_pool:
+                for result in attempt_pool.imap_unordered(
+                    self._execute_attempt, attempts
+                ):
+                    _config.transient.reportfile.write(
+                        json.dumps(result.as_dict()) + "\n"
+                    )
+                    attempts_completed.append(
+                        result
+                    )  # these will be out of original order
+                    attempt_bar.update(1)
+
+        else:
+            attempt_iterator = tqdm.tqdm(attempts, leave=False)
+            attempt_iterator.set_description(self.probename.replace("garak.", ""))
+            for this_attempt in attempt_iterator:
+                result = self._execute_attempt(this_attempt)
+                _config.transient.reportfile.write(json.dumps(result.as_dict()) + "\n")
+                attempts_completed.append(result)
+        return attempts_completed
 
     def probe(self, generator) -> Iterable[garak.attempt.Attempt]:
         """attempt to exploit the target generator, returning a list of results"""
@@ -160,33 +195,7 @@ class Probe:
             attempts_todo = self._buff_hook(attempts_todo)
 
         # iterate through attempts
-        attempts_completed: Iterable[garak.attempt.Attempt] = []
-
-        if (
-            _config.system.parallel_attempts
-            and _config.system.parallel_attempts > 1
-            and self.parallelisable_attempts
-            and len(attempts_todo) > 1
-        ):
-            from multiprocessing import Pool
-
-            attempt_bar = tqdm.tqdm(total=len(attempts_todo), leave=False)
-            attempt_bar.set_description(self.probename.replace("garak.", ""))
-
-            with Pool(_config.system.parallel_attempts) as attempt_pool:
-                for result in attempt_pool.imap_unordered(
-                    self._execute_attempt, attempts_todo
-                ):
-                    attempts_completed.append(
-                        result
-                    )  # these will be out of original order
-                    attempt_bar.update(1)
-
-        else:
-            attempt_iterator = tqdm.tqdm(attempts_todo, leave=False)
-            attempt_iterator.set_description(self.probename.replace("garak.", ""))
-            for this_attempt in attempt_iterator:
-                attempts_completed.append(self._execute_attempt(this_attempt))
+        attempts_completed = self._execute_all(attempts_todo)
 
         logging.debug(
             "probe return: %s with %s attempts", self, len(attempts_completed)

--- a/garak/probes/base.py
+++ b/garak/probes/base.py
@@ -139,7 +139,6 @@ class Probe:
         if self.post_buff_hook:
             this_attempt = self._postprocess_buff(this_attempt)
         this_attempt = self._postprocess_hook(this_attempt)
-        # access to this file should be single threaded, this may need to be adjusted as a logger
         self._generator_cleanup()
         return copy.deepcopy(this_attempt)
 

--- a/garak/probes/dan.py
+++ b/garak/probes/dan.py
@@ -8,10 +8,9 @@ now) probes and others in a similar vein.
 """
 import logging
 from typing import Iterable
-from tqdm import tqdm
 
 import garak.attempt
-import garak._config
+from garak import _config
 from garak.probes.base import Probe
 
 
@@ -536,7 +535,7 @@ class AutoDANCached(Probe):
 
     def __init__(
         self,
-        autodan_prompt_location: str = garak._config.transient.basedir
+        autodan_prompt_location: str = _config.transient.basedir
         / "resources"
         / "autodan"
         / "data"
@@ -607,33 +606,7 @@ class AutoDAN(Probe):
             attempts_todo = self._buff_hook(attempts_todo)
 
             # iterate through attempts
-            attempts_completed = []
-
-            if (
-                garak._config.system.parallel_attempts
-                and garak._config.system.parallel_attempts > 1
-                and self.parallelisable_attempts
-                and len(attempts_todo) > 1
-            ):
-                from multiprocessing import Pool
-
-                attempt_bar = tqdm(total=len(attempts_todo), leave=False)
-                attempt_bar.set_description(self.probename.replace("garak.", ""))
-
-                with Pool(garak._config.system.parallel_attempts) as attempt_pool:
-                    for result in attempt_pool.imap_unordered(
-                        self._execute_attempt, attempts_todo
-                    ):
-                        attempts_completed.append(
-                            result
-                        )  # these will be out of original order
-                        attempt_bar.update(1)
-
-            else:
-                attempt_iterator = tqdm(attempts_todo, leave=False)
-                attempt_iterator.set_description(self.probename.replace("garak.", ""))
-                for this_attempt in attempt_iterator:
-                    attempts_completed.append(self._execute_attempt(this_attempt))
+            attempts_completed = self._execute_all(attempts_todo)
 
             logging.debug(
                 "probe return: %s with %s attempts", self, len(attempts_completed)
@@ -669,9 +642,7 @@ class DanInTheWild(Probe):
         super().__init__()
 
         inthewild_path = str(
-            garak._config.transient.basedir
-            / "resources"
-            / "inthewild_jailbreak_llms.txt"
+            _config.transient.basedir / "resources" / "inthewild_jailbreak_llms.txt"
         )
 
         with open(inthewild_path, "r", encoding="utf-8") as f:

--- a/garak/probes/gcg.py
+++ b/garak/probes/gcg.py
@@ -8,8 +8,6 @@ Probes designed to disrupt a system prompt by appending an adversarial suffix.
 import logging
 from typing import List
 
-import tqdm
-
 from garak.resources.gcg import run_gcg
 from garak.probes.base import Probe
 from garak import _config
@@ -98,33 +96,7 @@ class GCG(Probe):
             attempts_todo = self._buff_hook(attempts_todo)
 
             # iterate through attempts
-            attempts_completed = []
-
-            if (
-                _config.system.parallel_attempts
-                and _config.system.parallel_attempts > 1
-                and self.parallelisable_attempts
-                and len(attempts_todo) > 1
-            ):
-                from multiprocessing import Pool
-
-                attempt_bar = tqdm.tqdm(total=len(attempts_todo), leave=False)
-                attempt_bar.set_description(self.probename.replace("garak.", ""))
-
-                with Pool(_config.system.parallel_attempts) as attempt_pool:
-                    for result in attempt_pool.imap_unordered(
-                        self._execute_attempt, attempts_todo
-                    ):
-                        attempts_completed.append(
-                            result
-                        )  # these will be out of original order
-                        attempt_bar.update(1)
-
-            else:
-                attempt_iterator = tqdm.tqdm(attempts_todo, leave=False)
-                attempt_iterator.set_description(self.probename.replace("garak.", ""))
-                for this_attempt in attempt_iterator:
-                    attempts_completed.append(self._execute_attempt(this_attempt))
+            attempts_completed = self._execute_all(attempts_todo)
 
             logging.debug(
                 "probe return: %s with %s attempts", self, len(attempts_completed)

--- a/tests/generators/test_openai.py
+++ b/tests/generators/test_openai.py
@@ -16,8 +16,8 @@ def test_openai_version():
 
 
 @pytest.mark.skipif(
-    os.getenv("OPENAI_API_KEY", None) is None,
-    reason="OpenAI API key is not set in OPENAI_API_KEY",
+    os.getenv(OpenAIGenerator.ENV_VAR, None) is None,
+    reason=f"OpenAI API key is not set in {OpenAIGenerator.ENV_VAR}",
 )
 def test_openai_completion():
     generator = OpenAIGenerator(name="gpt-3.5-turbo-instruct")
@@ -36,8 +36,8 @@ def test_openai_completion():
 
 
 @pytest.mark.skipif(
-    os.getenv("OPENAI_API_KEY", None) is None,
-    reason="OpenAI API key is not set in OPENAI_API_KEY",
+    os.getenv(OpenAIGenerator.ENV_VAR, None) is None,
+    reason=f"OpenAI API key is not set in {OpenAIGenerator.ENV_VAR}",
 )
 def test_openai_chat():
     generator = OpenAIGenerator(name="gpt-3.5-turbo")


### PR DESCRIPTION
Fix #493 

Conceptually since rest generator client objects should not retains state, this provides a pattern where `rest` generator client objects can be instantiated only when required and avoiding the need to `pickle` the client object when passing a generator to another process.

* refactor for just in time rest client for `OpenAI`
* ensure read and write of `_config.transient.reportfile` are in parent process only
* consolidate multiprocessing execution in `probes/base.py`

Verification testing preformed with:
```
python -m garak p dan.DanInTheWild -m openai -n gpt-4-turbo-preview -g 1 --parallel_attempts 20
```

Additional testing may be appropriate to validate changes to `base` and `gcg` probe flows are not impacted.