### PR TITLE
Pause FigStepTiny

### DIFF
--- a/garak/probes/visual_jailbreak.py
+++ b/garak/probes/visual_jailbreak.py
@@ -111,7 +111,7 @@ class FigStep(Probe):
 
 
 class FigStepTiny(FigStep, Probe):
-    active = True
+    active = False
 
     __doc__ = FigStep.__doc__ + " - Tiny version"
 


### PR DESCRIPTION
Set FigStepTiny to inactive until modality matching between detectors, probes, and generators is set up and tests are built do manage that. Can still be called manually.