### PR TITLE
Bugfix/visual jailbreak pause

### DIFF
--- a/docs/source/detectors.rst
+++ b/docs/source/detectors.rst
@@ -26,3 +26,4 @@ garak.detectors
    garak.detectors.specialwords
    garak.detectors.toxicity
    garak.detectors.xss
+   garak.detectors.visual_jailbreak

--- a/docs/source/garak.detectors.visual_jailbreak.rst
+++ b/docs/source/garak.detectors.visual_jailbreak.rst
@@ -1,0 +1,8 @@
+garak.detectors.visual_jailbreak
+================================
+
+.. automodule:: garak.detectors.visual_jailbreak
+   :members:
+   :undoc-members:
+   :show-inheritance:   
+

--- a/docs/source/garak.probes.visual_jailbreak.rst
+++ b/docs/source/garak.probes.visual_jailbreak.rst
@@ -1,0 +1,8 @@
+garak.probes.visual_jailbreak
+=============================
+
+.. automodule:: garak.probes.visual_jailbreak
+   :members:
+   :undoc-members:
+   :show-inheritance:   
+

--- a/docs/source/probes.rst
+++ b/docs/source/probes.rst
@@ -31,3 +31,4 @@ For a detailed oversight into how a probe operates, see :doc:`garak.probes.base.
    garak.probes.tap
    garak.probes.test
    garak.probes.xss
+   garak.probes.visual_jailbreak

--- a/garak/harnesses/pxd.py
+++ b/garak/harnesses/pxd.py
@@ -49,8 +49,6 @@ class PxD(Harness):
                 print(message)
                 logging.warning(message)
                 continue
-            if not probe.active:
-                continue
             detectors = []
             for detector_name in detector_names:
                 detector = _plugins.load_plugin(detector_name, break_on_fail=False)

--- a/garak/harnesses/pxd.py
+++ b/garak/harnesses/pxd.py
@@ -49,6 +49,8 @@ class PxD(Harness):
                 print(message)
                 logging.warning(message)
                 continue
+            if not probe.active:
+                continue
             detectors = []
             for detector_name in detector_names:
                 detector = _plugins.load_plugin(detector_name, break_on_fail=False)

--- a/garak/probes/visual_jailbreak.py
+++ b/garak/probes/visual_jailbreak.py
@@ -112,7 +112,7 @@ class FigStep(Probe):
 
 
 class FigStepTiny(FigStep, Probe):
-    active = True
+    active = False
 
     __doc__ = FigStep.__doc__ + " - Tiny version"
 

--- a/garak/probes/visual_jailbreak.py
+++ b/garak/probes/visual_jailbreak.py
@@ -82,6 +82,7 @@ class FigStep(Probe):
             }
             for f in os.listdir(safebench_data_dir)
             if f.endswith(".png")
+            and 1 <= int(f.split("_")[3]) <= 7  # skip last three sections, LO FA HC
         ]
 
     def __init__(self):

--- a/garak/probes/visual_jailbreak.py
+++ b/garak/probes/visual_jailbreak.py
@@ -56,12 +56,8 @@ class FigStep(Probe):
             # make the dir
             os.makedirs(safebench_data_dir)
         # do the download
-        self.safebench_image_filenames = (
-            open(self.safebench_image_catalog, "r", encoding="utf8")
-            .read()
-            .strip()
-            .split("\n")
-        )
+        with open(self.safebench_image_catalog, "r", encoding="utf8") as _f:
+            self.safebench_image_filenames = _f.read().strip().split("\n")
         for filename in tqdm.tqdm(
             self.safebench_image_filenames,
             leave=False,

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -56,15 +56,29 @@ def test_buff_list(capsys):
         ) or line.startswith("garak LLM security probe v")
 
 
-def test_run_all_probes(capsys):
-    cli.main(["-m", "test", "-p", "all", "-d", "always.Pass", "-g", "1"])
+def test_run_all_active_probes(capsys):
+    cli.main(
+        ["-m", "test", "-p", "all", "-d", "always.Pass", "-g", "1", "--narrow_output"]
+    )
     result = capsys.readouterr()
     last_line = result.out.strip().split("\n")[-1]
     assert re.match("^✔️  garak run complete in [0-9]+\\.[0-9]+s$", last_line)
 
 
-def test_run_all_detectors(capsys):
-    cli.main(["-m", "test", "-p", "blank.BlankPrompt", "-d", "all", "-g", "1"])
+def test_run_all_active_detectors(capsys):
+    cli.main(
+        [
+            "-m",
+            "test",
+            "-p",
+            "blank.BlankPrompt",
+            "-d",
+            "all",
+            "-g",
+            "1",
+            "--narrow_output",
+        ]
+    )
     result = capsys.readouterr()
     last_line = result.out.strip().split("\n")[-1]
     assert re.match("^✔️  garak run complete in [0-9]+\\.[0-9]+s$", last_line)

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -39,7 +39,7 @@ def test_docs_detectors(classname):
     file_path = os.path.join(doc_source, f"garak.detectors.{classname}.rst")
     assert os.path.isfile(file_path)
     assert os.path.getsize(file_path) > 0
-    category_file = os.path.join(doc_source, f"detectors.rst")
+    category_file = os.path.join(doc_source, "detectors.rst")
     target_doc = f"garak.detectors.{classname}\n"
     assert (
         open(category_file, "r", encoding="utf-8").read().find(target_doc) != -1
@@ -51,7 +51,7 @@ def test_docs_harnesses(classname):
     file_path = os.path.join(doc_source, f"garak.harnesses.{classname}.rst")
     assert os.path.isfile(file_path)
     assert os.path.getsize(file_path) > 0
-    category_file = os.path.join(doc_source, f"harnesses.rst")
+    category_file = os.path.join(doc_source, "harnesses.rst")
     target_doc = f"garak.harnesses.{classname}\n"
     assert (
         open(category_file, "r", encoding="utf-8").read().find(target_doc) != -1
@@ -75,7 +75,7 @@ def test_docs_generators(classname):
     file_path = os.path.join(doc_source, f"garak.generators.{classname}.rst")
     assert os.path.isfile(file_path)
     assert os.path.getsize(file_path) > 0
-    category_file = os.path.join(doc_source, f"generators.rst")
+    category_file = os.path.join(doc_source, "generators.rst")
     target_doc = f"garak.generators.{classname}\n"
     assert (
         open(category_file, "r", encoding="utf-8").read().find(target_doc) != -1
@@ -87,7 +87,7 @@ def test_docs_generators(classname):
     file_path = os.path.join(doc_source, f"garak.buffs.{classname}.rst")
     assert os.path.isfile(file_path)
     assert os.path.getsize(file_path) > 0
-    category_file = os.path.join(doc_source, f"buffs.rst")
+    category_file = os.path.join(doc_source, "buffs.rst")
     target_doc = f"garak.buffs.{classname}\n"
     assert (
         open(category_file, "r", encoding="utf-8").read().find(target_doc) != -1


### PR DESCRIPTION
Modality matching & selection isn't implemented in harnesses yet, so this plugin is disabled by default to avoid surprising UX when "all" is selected as a target. Also add docs