### PR TITLE
limit push test to main

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,11 @@
 name: Garak pytest
 
-on: [push,pull_request_target,workflow_dispatch]
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   pre_job:


### PR DESCRIPTION
There is benefit to tests run on `push` the trade off is sometimes confusing to users. For now we will reduce test runs to avoid executing tests on a branch push and defer testing to open of a PR or manual execution by the user. The `main` branch will still execute tests on `push` to ensure the protected branch tip is always in a known state.

Automation is helpful, avoiding alert fatigue from messages about failing tests on in progress branch also has value.