### PR TITLE
handle extant but closed `hitlogfile` file

### DIFF
--- a/garak/evaluators/base.py
+++ b/garak/evaluators/base.py
@@ -62,7 +62,13 @@ class Evaluator:
                 all_outputs += attempt.outputs
                 for idx, score in enumerate(attempt.detector_results[detector]):
                     if not self.test(score):  # if we don't pass
-                        if not _config.transient.hitlogfile:
+                        if (
+                            _config.transient.hitlogfile is None
+                            or _config.transient.hitlogfile.closed
+                        ):
+                            hitlog_mode = (
+                                "w" if _config.transient.hitlogfile is None else "a"
+                            )
                             if not _config.reporting.report_prefix:
                                 hitlog_filename = f"{_config.reporting.report_dir}/garak.{_config.transient.run_id}.hitlog.jsonl"
                             else:
@@ -72,7 +78,7 @@ class Evaluator:
                             logging.info("hit log in %s", hitlog_filename)
                             _config.transient.hitlogfile = open(
                                 hitlog_filename,
-                                "w",
+                                hitlog_mode,
                                 buffering=1,
                                 encoding="utf-8",
                             )


### PR DESCRIPTION
evalutors/base is now more defensive and can recover from closed hitlogfiles

cf. https://github.com/leondz/garak/pull/637#pullrequestreview-2044150946 - testing now passes with a `NIM_API_KEY` set 

resolves #599 

NB: This PR leaves unresolved the underlying misbehaviour that leads to `_config.transient.hitlogfile` closing before the scan completes. That behaviour is potentially a side-effect of insufficient state management of `_config`, tracked in #646. We might consider undoing this PR when #646 is resolved, or blocking it in order to testing #646. Adding an assert to monitor `hitlogfile` state may be sufficient when completing #646.

All that said: pending the larger change to `_config` state, this PR should enable hitlog file writing to at least recover from inconsistent state.