### PR TITLE
Guard cli run with invalid or incomplete config

### DIFF
--- a/garak/_config.py
+++ b/garak/_config.py
@@ -162,7 +162,8 @@ def parse_plugin_spec(
     from garak._plugins import enumerate_plugins
 
     if spec is None or spec.lower() in ("", "auto", "none"):
-        return []
+        return [], []
+    unknown_plugins = []
     if spec.lower() in ("all", "*"):
         plugin_names = [
             name
@@ -173,11 +174,15 @@ def parse_plugin_spec(
         plugin_names = []
         for clause in spec.split(","):
             if clause.count(".") < 1:
-                plugin_names += [
+                found_plugins = [
                     p
                     for p, a in enumerate_plugins(category=category)
                     if p.startswith(f"{category}.{clause}.") and a is True
                 ]
+                if len(found_plugins) > 0:
+                    plugin_names += found_plugins
+                else:
+                    unknown_plugins += [clause]
             else:
                 plugin_names += [f"{category}.{clause}"]  # spec parsing
 
@@ -196,4 +201,4 @@ def parse_plugin_spec(
         for plugin_to_skip in plugins_to_skip:
             plugin_names.remove(plugin_to_skip)
 
-    return plugin_names
+    return plugin_names, unknown_plugins

--- a/garak/_config.py
+++ b/garak/_config.py
@@ -184,7 +184,16 @@ def parse_plugin_spec(
                 else:
                     unknown_plugins += [clause]
             else:
-                plugin_names += [f"{category}.{clause}"]  # spec parsing
+                # validate the class exists
+                found_plugins = [
+                    p
+                    for p, a in enumerate_plugins(category=category)
+                    if p == f"{category}.{clause}" and a is True
+                ]
+                if len(found_plugins) > 0:
+                    plugin_names += found_plugins
+                else:
+                    unknown_plugins += [clause]
 
     if probe_tag_filter is not None and len(probe_tag_filter) > 1:
         plugins_to_skip = []

--- a/garak/_config.py
+++ b/garak/_config.py
@@ -17,7 +17,9 @@ import yaml
 
 version = -1  # eh why this is here? hm. who references it
 
-system_params = "verbose narrow_output parallel_requests parallel_attempts".split()
+system_params = (
+    "verbose narrow_output parallel_requests parallel_attempts skip_unknown".split()
+)
 run_params = "seed deprefix eval_threshold generations probe_tags interactive".split()
 plugins_params = "model_type model_name extended_detectors".split()
 reporting_params = "taxonomy report_prefix".split()

--- a/garak/_config.py
+++ b/garak/_config.py
@@ -188,7 +188,7 @@ def parse_plugin_spec(
                 found_plugins = [
                     p
                     for p, a in enumerate_plugins(category=category)
-                    if p == f"{category}.{clause}" and a is True
+                    if p == f"{category}.{clause}"
                 ]
                 if len(found_plugins) > 0:
                     plugin_names += found_plugins

--- a/garak/_config.py
+++ b/garak/_config.py
@@ -158,7 +158,7 @@ def load_config(
 
 def parse_plugin_spec(
     spec: str, category: str, probe_tag_filter: str = ""
-) -> List[str]:
+) -> tuple[List[str], List[str]]:
     from garak._plugins import enumerate_plugins
 
     if spec is None or spec.lower() in ("", "auto", "none"):

--- a/garak/cli.py
+++ b/garak/cli.py
@@ -448,10 +448,14 @@ def main(arguments=[]) -> None:
                 parsed_specs[spec_type] = names
                 if rejected is not None and len(rejected) > 0:
                     if not args.skip_unknown:
-                        raise ValueError(f"❌Unknown {spec_namespace}❌: {",".join(rejected)}")
+                        msg_list = ",".join(rejected)
+                        raise ValueError(f"❌Unknown {spec_namespace}❌: {msg_list}")
                     else:
                         header = f"Unknown {spec_namespace}:"
-                        msg = f"{Fore.LIGHTYELLOW_EX}{header}\n" + "\n".join([ f"{Fore.LIGHTYELLOW_EX + "SKIP" + Style.RESET_ALL} {spec}" for spec in rejected ])
+                        skip_msg = Fore.LIGHTYELLOW_EX + "SKIP" + Style.RESET_ALL
+                        msg = f"{Fore.LIGHTYELLOW_EX}{header}\n" + "\n".join(
+                            [f"{skip_msg} {spec}" for spec in rejected]
+                        )
                         logging.warning(f"{header} " + ",".join(rejected))
                         print(msg)
 
@@ -499,10 +503,16 @@ def main(arguments=[]) -> None:
             print(f"📜 reporting to {_config.transient.report_filename}")
 
             if parsed_specs["detector"] == []:
-                command.probewise_run(generator, parsed_specs["probe"], evaluator, parsed_specs["buff"])
+                command.probewise_run(
+                    generator, parsed_specs["probe"], evaluator, parsed_specs["buff"]
+                )
             else:
                 command.pxd_run(
-                    generator, parsed_specs["probe"], parsed_specs["detector"], evaluator, parsed_specs["buff"]
+                    generator,
+                    parsed_specs["probe"],
+                    parsed_specs["detector"],
+                    evaluator,
+                    parsed_specs["buff"],
                 )
 
             command.end_run()

--- a/garak/harnesses/base.py
+++ b/garak/harnesses/base.py
@@ -75,16 +75,18 @@ class Harness:
         :type announce_probe: bool, optional
         """
         if not detectors:
-            logging.warning("No detectors, nothing to do")
+            msg = "No detectors, nothing to do"
+            logging.warning(msg)
             if hasattr(_config.system, "verbose") and _config.system.verbose >= 2:
-                print("No detectors, nothing to do")
-            return None
+                print(msg)
+            raise ValueError(msg)
 
         if not probes:
-            logging.warning("No probes, nothing to do")
+            msg = "No probes, nothing to do"
+            logging.warning(msg)
             if hasattr(_config.system, "verbose") and _config.system.verbose >= 2:
-                print("No probes, nothing to do")
-            return None
+                print(msg)
+            raise ValueError(msg)
 
         for probe in probes:
             logging.debug("harness: probe start for %s", probe.probename)

--- a/garak/harnesses/probewise.py
+++ b/garak/harnesses/probewise.py
@@ -58,10 +58,11 @@ class ProbewiseHarness(Harness):
         """
 
         if not probenames:
-            logging.warning("No probes, nothing to do")
+            msg = "No probes, nothing to do"
+            logging.warning(msg)
             if hasattr(_config.system, "verbose") and _config.system.verbose >= 2:
-                print("No probes, nothing to do")
-            return None
+                print(msg)
+            raise ValueError(msg)
 
         self._load_buffs(buff_names)
 

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -77,6 +77,7 @@ def test_run_all_active_detectors(capsys):
             "-g",
             "1",
             "--narrow_output",
+            "--skip_unknown",
         ]
     )
     result = capsys.readouterr()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -460,6 +460,11 @@ def test_probespec_loading():
     assert _config.parse_plugin_spec(
         "atkgen.Tox,atkgen.ProbeDoesNotExist", "probes"
     ) == (["probes.atkgen.Tox"], ["atkgen.ProbeDoesNotExist"])
+    # accept known disabled class
+    assert _config.parse_plugin_spec("dan.DanInTheWild", "probes") == (
+        ["probes.dan.DanInTheWild"],
+        [],
+    )
     # gather all class entires for namespace
     assert _config.parse_plugin_spec("atkgen", "probes") == (["probes.atkgen.Tox"], [])
     assert _config.parse_plugin_spec("always", "detectors") == (

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -439,18 +439,21 @@ def test_blank_generator_instance_loads_cli_config():
 
 # test parsing of probespec
 def test_probespec_loading():
-    assert _config.parse_plugin_spec(None, "detectors") == []
-    assert _config.parse_plugin_spec("Auto", "probes") == []
-    assert _config.parse_plugin_spec("NONE", "probes") == []
-    assert _config.parse_plugin_spec("", "generators") == []
-    assert _config.parse_plugin_spec("atkgen", "probes") == ["probes.atkgen.Tox"]
+    assert _config.parse_plugin_spec(None, "detectors") == ([], [])
+    assert _config.parse_plugin_spec("Auto", "probes") == ([], [])
+    assert _config.parse_plugin_spec("NONE", "probes") == ([], [])
+    assert _config.parse_plugin_spec("", "generators") == ([], [])
+    assert _config.parse_plugin_spec("atkgen", "probes") == (["probes.atkgen.Tox"], [])
     assert _config.parse_plugin_spec(
         "long.test.class,another.long.test.class", "probes"
-    ) == ["probes.long.test.class", "probes.another.long.test.class"]
-    assert _config.parse_plugin_spec("always", "detectors") == [
-        "detectors.always.Fail",
-        "detectors.always.Pass",
-    ]
+    ) == (["probes.long.test.class", "probes.another.long.test.class"], [])
+    assert _config.parse_plugin_spec("always", "detectors") == (
+        [
+            "detectors.always.Fail",
+            "detectors.always.Pass",
+        ],
+        [],
+    )
 
 
 def test_buff_config_assertion():
@@ -464,16 +467,18 @@ def test_buff_config_assertion():
 
 
 def test_tag_filter():
-    assert (
-        _config.parse_plugin_spec("atkgen", "probes", probe_tag_filter="LOL NULL") == []
+    assert _config.parse_plugin_spec(
+        "atkgen", "probes", probe_tag_filter="LOL NULL"
+    ) == ([], [])
+    assert _config.parse_plugin_spec("*", "probes", probe_tag_filter="avid") != ([], [])
+    assert _config.parse_plugin_spec("all", "probes", probe_tag_filter="owasp:llm") != (
+        [],
+        [],
     )
-    assert _config.parse_plugin_spec("*", "probes", probe_tag_filter="avid") != []
-    assert (
-        _config.parse_plugin_spec("all", "probes", probe_tag_filter="owasp:llm") != []
-    )
-    assert "probes.lmrc.SexualContent" in _config.parse_plugin_spec(
+    found, rejected = _config.parse_plugin_spec(
         "all", "probes", probe_tag_filter="risk-cards:lmrc:sexual_content"
     )
+    assert "probes.lmrc.SexualContent" in found
 
 
 def test_report_prefix_with_hitlog_no_explode():


### PR DESCRIPTION
Fix #191 

* probe/detector/buff configuration checks
  * invalid or missing values generate an error message and exit early
  * a [bool] cli argument `--skip_unknown` logs unknown configurations & continues to `start_run`
* front load argument parsing for probes and detectors
  * defers run log creation until run config is validated

Local test examples
```
python -m garak -m test -n mistralai/mixtral-8x22b-v0.1 -g 1 -p dan.DanInTheWild,doesnotexist,dan.Invalid --skip_unknown
python -m garak -m test -n mistralai/mixtral-8x22b-v0.1 -g 1 -p dan.DanInTheWild,doesnotexist
python -m garak -m test -n mistralai/mixtral-8x22b-v0.1 -g 1 -p doesnotexist
python -m garak -m test -n mistralai/mixtral-8x22b-v0.1 -g 1 -p doesnotexist --skip_unknown
```

