### PR TITLE
Catch generic exception from transformers in huggingface

### DIFF
--- a/garak/generators/huggingface.py
+++ b/garak/generators/huggingface.py
@@ -497,9 +497,10 @@ class Model(Generator, HFCompatible):
                     outputs = self.model.generate(
                         **inputs, generation_config=self.generation_config
                     )
-                except IndexError as e:
+                except Exception as e:
                     if len(prompt) == 0:
-                        return [""] * generations_this_call
+                        logging.exception("Error calling generate for empty prompt")
+                        return [None] * generations_this_call
                     else:
                         raise e
                 text_output = self.tokenizer.batch_decode(

--- a/tests/generators/test_huggingface.py
+++ b/tests/generators/test_huggingface.py
@@ -53,4 +53,4 @@ def test_model():
     output = g.generate("")
     assert len(output) == DEFAULT_GENERATIONS_QTY
     for item in output:
-        assert isinstance(item, str)
+        assert item is None  # gpt2 is known raise exception returning `None`


### PR DESCRIPTION
Explicitly return `None` for all results and log when exception raised for empty prompt

Testing update reflect expected results.