### PR TITLE
rest generator response must be a list

### DIFF
--- a/garak/generators/rest.py
+++ b/garak/generators/rest.py
@@ -286,7 +286,7 @@ class RestGenerator(Generator):
                 raise ConnectionError(error_msg)
 
         if not self.response_json:
-            return str(resp.text)
+            return [str(resp.text)]
 
         response_object = json.loads(resp.content)
 
@@ -301,7 +301,7 @@ class RestGenerator(Generator):
             len(self.response_json_field) > 0
         ), "response_json_field needs to be complete if response_json is true; ValueError should have been raised in constructor"
         if self.response_json_field[0] != "$":
-            response = response_object[self.response_json_field]
+            response = [response_object[self.response_json_field]]
         else:
             field_path_expr = jsonpath_ng.parse(self.response_json_field)
             responses = field_path_expr.find(response_object)
@@ -318,7 +318,7 @@ class RestGenerator(Generator):
                     "RestGenerator JSONPath in response_json_field yielded nothing. Response content: %s"
                     % repr(resp.content)
                 )
-                return None
+                return [None]
 
         return response
 

--- a/tests/generators/test_rest.py
+++ b/tests/generators/test_rest.py
@@ -40,7 +40,7 @@ def test_plaintext_rest(requests_mock):
     )
     generator = RestGenerator()
     output = generator._call_model("sup REST")
-    assert output == DEFAULT_TEXT_RESPONSE
+    assert output == [DEFAULT_TEXT_RESPONSE]
 
 
 @pytest.mark.usefixtures("set_rest_config")
@@ -55,7 +55,7 @@ def test_json_rest_top_level(requests_mock):
     print(generator.response_json)
     print(generator.response_json_field)
     output = generator._call_model("Who is Enabran Tain's son?")
-    assert output == DEFAULT_TEXT_RESPONSE
+    assert output == [DEFAULT_TEXT_RESPONSE]
 
 
 @pytest.mark.usefixtures("set_rest_config")


### PR DESCRIPTION
To be compatible with changes from #637 `rest.Generator` needs to return single responses as a list.

Should I expand this and to check if singular key in `response_json_field` is already a list?