### PR TITLE
Split NVCF generator into completion chat

### DIFF
--- a/garak/generators/nvcf.py
+++ b/garak/generators/nvcf.py
@@ -33,7 +33,7 @@ class NvcfChat(Generator):
 
     def __init__(self, name=None, generations=10):
         self.name = name
-        self.fullname = f"NVCF {self.name}"
+        self.fullname = f"{self.generator_family_name} {self.__class__.__name__}"
         self.seed = _config.run.seed
 
         if self.name is None:

--- a/garak/generators/nvcf.py
+++ b/garak/generators/nvcf.py
@@ -114,6 +114,7 @@ class NvcfChat(Generator):
 
         if 400 <= response.status_code < 600:
             logging.warning("nvcf : returned error code %s", response.status_code)
+            logging.warning("nvcf : payload %s", repr(payload))
             logging.warning("nvcf : returned error body %s", response.content)
             if response.status_code == 400 and prompt == "":
                 # error messages for refusing a blank prompt are fragile and include multi-level wrapped JSON, so this catch is a little broad

--- a/garak/generators/nvcf.py
+++ b/garak/generators/nvcf.py
@@ -17,7 +17,7 @@ from garak.generators.base import Generator
 
 
 class NvcfChat(Generator):
-    """Wrapper for NVIDIA Cloud Functions Chat models via NGC. Expects NGC_API_KEY and ORG_ID environment variables."""
+    """Wrapper for NVIDIA Cloud Functions Chat models via NGC. Expects NVCF_API_KEY environment variable."""
 
     supports_multiple_generations = False
     generator_family_name = "NVCF"
@@ -138,7 +138,7 @@ class NvcfChat(Generator):
 
 
 class NvcfCompletion(NvcfChat):
-    """Wrapper for NVIDIA Cloud Functions Completion models via NGC. Expects NGC_API_KEY and ORG_ID environment variables."""
+    """Wrapper for NVIDIA Cloud Functions Completion models via NGC. Expects NVCF_API_KEY environment variables."""
 
     def _build_payload(self, prompt) -> dict:
 

--- a/garak/generators/nvcf.py
+++ b/garak/generators/nvcf.py
@@ -33,7 +33,7 @@ class NvcfChat(Generator):
 
     def __init__(self, name=None, generations=10):
         self.name = name
-        self.fullname = f"{self.generator_family_name} {self.__class__.__name__}"
+        self.fullname = f"{self.generator_family_name} {self.__class__.__name__} {self.name}"
         self.seed = _config.run.seed
 
         if self.name is None:

--- a/garak/generators/nvcf.py
+++ b/garak/generators/nvcf.py
@@ -33,7 +33,9 @@ class NvcfChat(Generator):
 
     def __init__(self, name=None, generations=10):
         self.name = name
-        self.fullname = f"{self.generator_family_name} {self.__class__.__name__} {self.name}"
+        self.fullname = (
+            f"{self.generator_family_name} {self.__class__.__name__} {self.name}"
+        )
         self.seed = _config.run.seed
 
         if self.name is None:
@@ -68,7 +70,7 @@ class NvcfChat(Generator):
         return payload
 
     def _extract_text_output(self, response) -> str:
-        return response["choices"][0]["message"]["content"]
+        return [c["message"]["content"] for c in response["choices"]]
 
     @backoff.on_exception(
         backoff.fibo,
@@ -134,7 +136,7 @@ class NvcfChat(Generator):
         else:
             response_body = response.json()
 
-            return [self._extract_text_output(response_body)]
+            return self._extract_text_output(response_body)
 
 
 class NvcfCompletion(NvcfChat):
@@ -153,7 +155,7 @@ class NvcfCompletion(NvcfChat):
         return payload
 
     def _extract_text_output(self, response) -> str:
-        return response["choices"][0]["text"]
+        return [c["text"] for c in response["choices"]]
 
 
 DEFAULT_CLASS = "NvcfChat"

--- a/garak/generators/nvcf.py
+++ b/garak/generators/nvcf.py
@@ -16,8 +16,8 @@ from garak import _config
 from garak.generators.base import Generator
 
 
-class NvcfGenerator(Generator):
-    """Wrapper for NVIDIA Cloud Functions via NGC. Expects NGC_API_KEY and ORG_ID environment variables."""
+class NvcfChat(Generator):
+    """Wrapper for NVIDIA Cloud Functions Chat models via NGC. Expects NGC_API_KEY and ORG_ID environment variables."""
 
     supports_multiple_generations = False
     generator_family_name = "NVCF"
@@ -55,6 +55,21 @@ class NvcfGenerator(Generator):
             "Accept": "application/json",
         }
 
+    def _build_payload(self, prompt) -> dict:
+
+        payload = {
+            "messages": [{"content": prompt, "role": "user"}],
+            "temperature": self.temperature,
+            "top_p": self.top_p,
+            "max_tokens": self.max_tokens,
+            "stream": False,
+        }
+
+        return payload
+
+    def _extract_text_output(self, response) -> str:
+        return response["choices"][0]["message"]["content"]
+
     @backoff.on_exception(
         backoff.fibo,
         (
@@ -71,13 +86,14 @@ class NvcfGenerator(Generator):
 
         session = requests.Session()
 
-        payload = {
-            "messages": [{"content": prompt, "role": "user"}],
-            "temperature": self.temperature,
-            "top_p": self.top_p,
-            "max_tokens": self.max_tokens,
-            "stream": False,
-        }
+        payload = self._build_payload(prompt)
+
+        ## NB config indexing scheme to be deprecated
+        config_class = f"nvcf.{self.__class__.__name__}"
+        if config_class in _config.plugins.generators:
+            if "payload" in _config.plugins.generators[config_class]:
+                for k, v in _config.plugins.generators[config_class]["payload"].items():
+                    payload[k] = v
 
         if self.seed is not None:
             payload["seed"] = self.seed
@@ -117,7 +133,26 @@ class NvcfGenerator(Generator):
         else:
             response_body = response.json()
 
-            return [response_body["choices"][0]["message"]["content"]]
+            return [self._extract_text_output(response_body)]
 
 
-DEFAULT_CLASS = "NvcfGenerator"
+class NvcfCompletion(NvcfChat):
+    """Wrapper for NVIDIA Cloud Functions Completion models via NGC. Expects NGC_API_KEY and ORG_ID environment variables."""
+
+    def _build_payload(self, prompt) -> dict:
+
+        payload = {
+            "prompt": prompt,
+            "temperature": self.temperature,
+            "top_p": self.top_p,
+            "max_tokens": self.max_tokens,
+            "stream": False,
+        }
+
+        return payload
+
+    def _extract_text_output(self, response) -> str:
+        return response["choices"][0]["text"]
+
+
+DEFAULT_CLASS = "NvcfChat"


### PR DESCRIPTION
NVCF models support at least two interfaces - Completion and Chat styles. They also sometimes require custom headers. This PR splits the NVCF class into two, one for each interface, providing separate methods for building the payload and parsing the output under each interface style. It also adds code to allow external configuration of the payload fields that the NVCF endpoint is queried with.