### PR TITLE
patch ambiguity around generate() filtering or not filtering `None`s

### DIFF
--- a/tests/generators/test_huggingface.py
+++ b/tests/generators/test_huggingface.py
@@ -50,7 +50,9 @@ def test_model():
     assert g.max_tokens == 99
     g.temperature = 0.1
     assert g.temperature == 0.1
+    # this is expected to lead to [None]*DEFAULT_GENERATIONS_QTY, which generate() filters to []
     output = g.generate("")
-    assert len(output) == DEFAULT_GENERATIONS_QTY
-    for item in output:
-        assert item is None  # gpt2 is known raise exception returning `None`
+    assert len(output) == 0 
+    #assert len(output) == DEFAULT_GENERATIONS_QTY
+    #for item in output:
+    #    assert item is None  # gpt2 is known to raise exception returning `None`


### PR DESCRIPTION
While the aspirational behaviour of `generate()` has changed from filtering out `None` entries to leaving them in, allowing generators to express out-of-band failures to detectors, the current state of detectors' ability to handle `None` well is unknown. Until that can be stabilised, the code in `generate()` that filters out `None` should remain, and this Hugging Face test around empty input (leading to an exception) should expect the current, and not aspirational, behaviour. When we get to the goal state, this revised test should fail, and the code there can be updated accordingly.