### PR TITLE
restore `req_template_json_object` lost in refactor

### DIFF
--- a/garak/configurable.py
+++ b/garak/configurable.py
@@ -69,7 +69,7 @@ class Configurable:
                 # should this be coupled to `_plugins`?
                 continue
             if (
-                isinstance(self._supported_params, list)
+                isinstance(self._supported_params, tuple)
                 and k not in self._supported_params
             ):
                 # if the class has a set of supported params skip unknown params

--- a/garak/generators/rest.py
+++ b/garak/generators/rest.py
@@ -130,6 +130,7 @@ class RestGenerator(Generator):
         "headers",
         "response_json",
         "response_json_field",
+        "req_template_json_object",
         "request_timeout",
         "ratelimit_codes",
         "temperature",
@@ -153,7 +154,7 @@ class RestGenerator(Generator):
             hasattr(self, "req_template_json_object")
             and self.req_template_json_object is not None
         ):
-            self.req_template = json.dumps(self.req_template_object)
+            self.req_template = json.dumps(self.req_template_json_object)
 
         if self.response_json:
             if self.response_json_field is None:

--- a/garak/generators/rest.py
+++ b/garak/generators/rest.py
@@ -66,23 +66,23 @@ class RestGenerator(Generator):
     and response value are both under the ``text`` key, we'd define the service
     using something like: ::
 
-        {"rest"
+    {
+        "rest": {
             "RestGenerator": {
-                {
-                    "name": "example service",
-                    "uri": "https://example.ai/llm",
-                    "method": "post",
-                    "headers":{
-                        "X-Authorization": "$KEY",
-                    },
-                    "req_template_json_object":{
-                        "text":"$INPUT"
-                    },
-                    "response_json": true,
-                    "response_json_field": "text"
-                }
+                "name": "example service",
+                "uri": "https://example.ai/llm",
+                "method": "post",
+                "headers": {
+                    "X-Authorization": "$KEY",
+                },
+                "req_template_json_object": {
+                    "text": "$INPUT"
+                },
+                "response_json": true,
+                "response_json_field": "text"
             }
         }
+    }
 
     NB. ``response_json_field`` can also be a JSONPath, for JSON responses where
     the target text is not in a top level field. It is treated as a JSONPath

--- a/tests/test_configurable.py
+++ b/tests/test_configurable.py
@@ -77,7 +77,7 @@ def test_config_supported_params(generator_sub_config):
     class mock_supported(mockConfigurable):
         __module__ = "garak.generators.mock"
 
-        _supported_params = ["constructor_param", "defaulted_constructor_param"]
+        _supported_params = ("constructor_param", "defaulted_constructor_param")
 
     m = mock_supported(config_root=generator_sub_config)
     for k, v in generator_sub_config.generators["mock"].items():


### PR DESCRIPTION
refactor in #711 attempts to access the wrong key after configuration and needs to `allow` the key by default.