### PR TITLE
utilize GarakException in cli

### DIFF
--- a/garak/_plugins.py
+++ b/garak/_plugins.py
@@ -10,6 +10,7 @@ import os
 from typing import List
 
 from garak import _config
+from garak.exception import GarakException
 
 PLUGIN_TYPES = ("probes", "detectors", "generators", "harnesses", "buffs")
 PLUGIN_CLASSES = ("Probe", "Detector", "Generator", "Harness", "Buff")
@@ -151,7 +152,7 @@ def load_plugin(path, break_on_fail=True, config_root=_config) -> object:
             "error instantiating module %s class %s", str(mod), plugin_class_name
         )
         if break_on_fail:
-            raise Exception(e) from e
+            raise GarakException(e) from e
         else:
             return False
 

--- a/garak/cli.py
+++ b/garak/cli.py
@@ -12,6 +12,7 @@ def main(arguments=[]) -> None:
 
     from garak import __version__, __description__
     from garak import _config
+    from garak.exception import GarakException
 
     _config.transient.starttime = datetime.datetime.now()
     _config.transient.starttime_iso = _config.transient.starttime.isoformat()
@@ -512,10 +513,11 @@ def main(arguments=[]) -> None:
                     "💡 try setting --model_type (--model_name is currently set but not --model_type)"
                 )
             logging.info("nothing to do 🤷")
-    except KeyboardInterrupt:
+    except KeyboardInterrupt as e:
         msg = "User cancel received, terminating all runs"
+        logging.exception(e)
         logging.info(msg)
         print(msg)
-    except ValueError as e:
-        logging.error(e)
+    except (ValueError, GarakException) as e:
+        logging.exception(e)
         print(e)


### PR DESCRIPTION
Fix #619 

This may not be everything desired in #619, referencing as it mitigates some of the needs there.

* when a plugin fails to load raise `GarakException`
* log the exception trace when error handling in `cli`