### PR TITLE
require probes to match input modality of the generator

### DIFF
--- a/garak/generators/huggingface.py
+++ b/garak/generators/huggingface.py
@@ -561,7 +561,7 @@ class LLaVA(Generator):
         # https://github.com/haotian-liu/LLaVA/issues/1095#:~:text=Conceptually%2C%20as%20long%20as%20the%20total%20tokens%20are%20within%204K%2C%20it%20would%20be%20fine%2C%20so%20exist_tokens%20%2B%20max_new_tokens%20%3C%204K%20is%20the%20golden%20rule.
         "max_tokens": 4000,
         # consider shifting below to kwargs or llava_kwargs that is a dict to allow more customization
-        "torch_dtype": "float16",
+        "torch_dtype": torch.float16,
         "low_cpu_mem_usage": True,
         "device_map": "cuda:0",
     }

--- a/garak/harnesses/base.py
+++ b/garak/harnesses/base.py
@@ -96,7 +96,7 @@ class Harness(Configurable):
                 continue
             # TODO: refactor this to allow `compatible` probes instead of direct match
             if probe.modality["in"] != model.modality["in"]:
-                logging.warning("probe skipped due to modality mismatch: %s", self)
+                logging.warning("probe skipped due to modality mismatch: %s", probe)
                 continue
 
             attempt_results = probe.probe(model)

--- a/garak/harnesses/base.py
+++ b/garak/harnesses/base.py
@@ -96,7 +96,11 @@ class Harness(Configurable):
                 continue
             # TODO: refactor this to allow `compatible` probes instead of direct match
             if probe.modality["in"] != model.modality["in"]:
-                logging.warning("probe skipped due to modality mismatch: %s", probe)
+                logging.warning(
+                    "probe skipped due to modality mismatch: %s - model expects %s",
+                    probe.probename,
+                    model.modality["in"],
+                )
                 continue
 
             attempt_results = probe.probe(model)

--- a/garak/harnesses/base.py
+++ b/garak/harnesses/base.py
@@ -94,6 +94,11 @@ class Harness(Configurable):
             logging.debug("harness: probe start for %s", probe.probename)
             if not probe:
                 continue
+            # TODO: refactor this to allow `compatible` probes instead of direct match
+            if probe.modality["in"] != model.modality["in"]:
+                logging.warning("probe skipped due to modality mismatch: %s", self)
+                continue
+
             attempt_results = probe.probe(model)
             assert isinstance(attempt_results, list)
 


### PR DESCRIPTION
* test modality for full input match
* log a warning for probes skipped due to mismatch

More work is likely to be needed so a `TODO` has been noted. Longer term goal may be to have some compatibility matrix for instance to allow sending `text` only input to models that support `text + image`.

Future improvements will likely be be linked with work in #602 