### PR TITLE
only set generations if still default

### DIFF
--- a/garak/generators/base.py
+++ b/garak/generators/base.py
@@ -43,7 +43,11 @@ class Generator(Configurable):
             self.description = self.__doc__.split("\n")[0]
         if name:
             self.name = name
-        self.generations = generations
+        if (
+            not hasattr(self, "generations")
+            or getattr(self, "generations", None) == self.DEFAULT_PARAMS["generations"]
+        ):
+            self.generations = generations
         if "fullname" not in dir(self):
             if self.generator_family_name is not None:
                 self.fullname = f"{self.generator_family_name}:{self.name}"

--- a/garak/generators/cohere.py
+++ b/garak/generators/cohere.py
@@ -29,7 +29,7 @@ class CohereGenerator(Generator):
     """
 
     ENV_VAR = "COHERE_API_KEY"
-    DEFAULT_PARAMS = {
+    DEFAULT_PARAMS = Generator.DEFAULT_PARAMS | {
         "temperature": 0.750,
         "k": 0,
         "p": 0.75,

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -18,8 +18,9 @@ def test_attempt_sticky_params(capsys):
         .read()
         .split("\n")
     )
+    # Note: the line numbers below are based on respecting the `-g 1` options passed
     complete_atkgen = json.loads(reportlines[3])  # status 2 for the one atkgen attempt
-    complete_dan = json.loads(reportlines[23])  # status 2 for the one dan attempt
+    complete_dan = json.loads(reportlines[6])  # status 2 for the one dan attempt
     assert complete_atkgen["notes"] != {}
     assert complete_dan["notes"] == {}
     assert complete_atkgen["notes"] != complete_dan["notes"]


### PR DESCRIPTION
When generations is set via config ignore the constructor provided value.

Planned revision to `Generator` will remove `generations` from the constructor furher ensuring the value is default or supplied on a `config_root`.

* only set self.generations if still matches default
* expand Cohere defaults to include `Generator` defaults
* restore `test_attempts` line selection with note about `why` the line is correct