### PR TITLE
Refactor `huggingface` config support

### DIFF
--- a/garak/configurable.py
+++ b/garak/configurable.py
@@ -88,6 +88,8 @@ class Configurable:
                     )
                 ):
                     continue
+                if isinstance(v, dict):  # if value is an existing dictionary merge
+                    v = getattr(self, k) | v
             setattr(self, k, v)  # This will set attribute to the full dictionary value
 
     def _apply_missing_instance_defaults(self):
@@ -95,6 +97,9 @@ class Configurable:
         if hasattr(self, "DEFAULT_PARAMS"):
             for k, v in self.DEFAULT_PARAMS.items():
                 if not hasattr(self, k):
+                    setattr(self, k, v)
+                elif isinstance(v, dict):
+                    v = v | getattr(self, k)
                     setattr(self, k, v)
 
     def _validate_env_var(self):

--- a/garak/generators/base.py
+++ b/garak/generators/base.py
@@ -27,6 +27,7 @@ class Generator(Configurable):
 
     active = True
     generator_family_name = None
+    parallel_capable = True
 
     # support mainstream any-to-any large models
     # legal element for str list `modality['in']`: 'text', 'image', 'audio', 'video', '3d'

--- a/garak/generators/huggingface.py
+++ b/garak/generators/huggingface.py
@@ -61,23 +61,23 @@ class HFCompatible:
 
         args = {}
 
-        parameters = inspect.signature(hf_constructor).parameters
+        params_to_process = inspect.signature(hf_constructor).parameters
 
-        if "model" in parameters:
+        if "model" in params_to_process:
             args["model"] = self.name
             # expand for
-            parameters = {"do_sample": True} | parameters
+            params_to_process = {"do_sample": True} | params_to_process
         else:
             # callable is for a Pretrained class also map standard `pipeline` params
             from transformers import pipeline
 
-            parameters = (
+            params_to_process = (
                 {"low_cpu_mem_usage": True}
-                | parameters
+                | params_to_process
                 | inspect.signature(pipeline).parameters
             )
 
-        for k in parameters:
+        for k in params_to_process:
             if k == "model":
                 continue  # special case `model` comes from `name` in the generator
             if k in params:
@@ -89,7 +89,7 @@ class HFCompatible:
                     continue
                 if (
                     k == "device"
-                    and "device_map" in parameters
+                    and "device_map" in params_to_process
                     and "device_map" in params
                 ):
                     # per transformers convention hold `device_map` before `device`
@@ -103,9 +103,13 @@ class HFCompatible:
         import torch.cuda
 
         selected_device = None
-        if self.hf_args["device"] is not None:
+        if self.hf_args.get("device", None) is not None:
             if isinstance(self.hf_args["device"], int):
                 # this assumes that indexed only devices selections means `cuda`
+                if self.hf_args["device"] < 0:
+                    msg = f"device {self.hf_args['device']} requested but CUDA device numbering starts at zero. Use 'device: cpu' to request CPU."
+                    logging.critical(msg)
+                    raise ValueError(msg)
                 selected_device = torch.device("cuda:" + str(self.hf_args["device"]))
             else:
                 selected_device = torch.device(self.hf_args["device"])
@@ -271,8 +275,6 @@ class ConversationalPipeline(Pipeline, HFCompatible):
 
         if _config.run.seed is not None:
             set_seed(_config.run.seed)
-
-        import torch.cuda
 
         # Note that with pipeline, in order to access the tokenizer, model, or device, you must get the attribute
         # directly from self.generator instead of from the ConversationalPipeline object itself.

--- a/garak/generators/huggingface.py
+++ b/garak/generators/huggingface.py
@@ -563,6 +563,7 @@ class Model(Pipeline, HFCompatible):
     def _clear_client(self):
         self.model = None
         self.config = None
+        self.tokenizer = None
         self.generation_config = None
 
     def _call_model(

--- a/garak/generators/huggingface.py
+++ b/garak/generators/huggingface.py
@@ -87,7 +87,8 @@ class Pipeline(Generator, HFCompatible):
             do_sample=self.do_sample,
             device=self.device,
         )
-        self.deprefix_prompt = self.name in models_to_deprefix
+        if not hasattr(self, "deprefix_prompt"):
+            self.deprefix_prompt = self.name in models_to_deprefix
         if _config.loaded:
             if _config.run.deprefix is True:
                 self.deprefix_prompt = True
@@ -173,7 +174,8 @@ class OptimumPipeline(Pipeline, HFCompatible):
             device=self.device,
             use_fp8=use_fp8,
         )
-        self.deprefix_prompt = name in models_to_deprefix
+        if not hasattr(self, "deprefix_prompt"):
+            self.deprefix_prompt = self.name in models_to_deprefix
         if _config.loaded:
             if _config.run.deprefix is True:
                 self.deprefix_prompt = True
@@ -219,7 +221,8 @@ class ConversationalPipeline(Generator, HFCompatible):
             device=self.device,
         )
         self.conversation = Conversation()
-        self.deprefix_prompt = self.name in models_to_deprefix
+        if not hasattr(self, "deprefix_prompt"):
+            self.deprefix_prompt = self.name in models_to_deprefix
         if _config.loaded:
             if _config.run.deprefix is True:
                 self.deprefix_prompt = True
@@ -494,7 +497,8 @@ class Model(Generator, HFCompatible):
             config=self.config,
         ).to(self.init_device)
 
-        self.deprefix_prompt = self.name in models_to_deprefix
+        if not hasattr(self, "deprefix_prompt"):
+            self.deprefix_prompt = self.name in models_to_deprefix
 
         if self.config.tokenizer_class:
             self.tokenizer = transformers.AutoTokenizer.from_pretrained(

--- a/garak/generators/huggingface.py
+++ b/garak/generators/huggingface.py
@@ -56,6 +56,7 @@ class Pipeline(Generator, HFCompatible):
 
     generator_family_name = "Hugging Face 🤗 pipeline"
     supports_multiple_generations = True
+    parallel_capable = False
 
     def __init__(
         self, name="", do_sample=True, generations=10, device=0, config_root=_config
@@ -98,9 +99,9 @@ class Pipeline(Generator, HFCompatible):
             if _config.run.deprefix is True:
                 self.deprefix_prompt = True
 
-                self._set_hf_context_len(self.generator.model.config)
+        self._set_hf_context_len(self.generator.model.config)
 
-    def _clear_client():
+    def _clear_client(self):
         self.generator = None
 
     def _call_model(
@@ -237,7 +238,7 @@ class ConversationalPipeline(Pipeline, HFCompatible):
         if isinstance(prompt, str):
             self.conversation.add_message({"role": "user", "content": prompt})
             self.conversation = self.generator(self.conversation)
-            generations = [self.conversation[-1]["content"]]
+            generations = [self.conversation[-1]["content"]]  # what is this doing?
 
         elif isinstance(prompt, list):
             from transformers import Conversation

--- a/garak/probes/base.py
+++ b/garak/probes/base.py
@@ -150,6 +150,7 @@ class Probe(Configurable):
         return copy.deepcopy(this_attempt)
 
     def _execute_all(self, attempts) -> Iterable[garak.attempt.Attempt]:
+        """handles sending a set of attempt to the generator"""
         attempts_completed: Iterable[garak.attempt.Attempt] = []
 
         if (
@@ -157,6 +158,7 @@ class Probe(Configurable):
             and _config.system.parallel_attempts > 1
             and self.parallelisable_attempts
             and len(attempts) > 1
+            and self.generator.parallel_capable
         ):
             from multiprocessing import Pool
 

--- a/tests/generators/test_huggingface.py
+++ b/tests/generators/test_huggingface.py
@@ -1,11 +1,25 @@
 import transformers
 import garak.generators.huggingface
+from garak._config import GarakSubConfig
 
 DEFAULT_GENERATIONS_QTY = 10
 
 
 def test_pipeline():
-    g = garak.generators.huggingface.Pipeline("gpt2")
+    gen_config = {
+        "huggingface": {
+            "Pipeline": {
+                "name": "gpt2",
+                "hf_args": {
+                    "device": "cpu",
+                },
+            }
+        }
+    }
+    config_root = GarakSubConfig()
+    setattr(config_root, "generators", gen_config)
+
+    g = garak.generators.huggingface.Pipeline("gpt2", config_root=config_root)
     assert g.name == "gpt2"
     assert g.generations == DEFAULT_GENERATIONS_QTY
     assert isinstance(g.generator, transformers.pipelines.text_generation.Pipeline)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -19,23 +19,27 @@ CONFIGURABLE_YAML = """
 plugins:
   generators:
     huggingface:
-      dtype: general
-      gpu: 0
+      hf_args:
+        torch_dtype: float16
       Pipeline:
-        dtype: bfloat16
+        hf_args:
+            device: cuda
   probes:
     test:
       generators:
         huggingface:
             Pipeline:
-              dtype: for_probe
+                hf_args:
+                    torch_dtype: float16
   detector:
       test:
         val: tests
         Blank:
           generators:
             huggingface:
-                gpu: 1
+                hf_args:
+                    torch_dtype: float16
+                    device: cuda:1
                 Pipeline:
                   dtype: for_detector
   buffs:
@@ -43,7 +47,8 @@ plugins:
         Blank:
           generators:
             huggingface:
-                gpu: 1
+                hf_args:
+                    device: cuda:0
                 Pipeline:
                   dtype: for_detector
 """.encode(

--- a/tests/test_configurable.py
+++ b/tests/test_configurable.py
@@ -24,7 +24,13 @@ class mockConfigurable(Configurable):
     # Configurable is coupled to hierarchy of plugin types
     __module__ = "garak.generators.mock"
 
-    DEFAULT_PARAMS = {"class_var": "from_class"}
+    DEFAULT_PARAMS = {
+        "class_var": "from_class",
+        "class_dict_var": {
+            "dict_a": "dict_val",
+            "dict_b": "dict_val",
+        },
+    }
 
     def __init__(
         self,
@@ -63,6 +69,17 @@ def test_param_provided(generator_sub_config):
 def test_class_vars_propagate_to_instance(generator_sub_config):
     m = mockConfigurable(config_root=generator_sub_config)
     assert m.class_var == m.DEFAULT_PARAMS["class_var"]
+    assert m.class_dict_var == m.DEFAULT_PARAMS["class_dict_var"]
+
+
+# when a default parameter dictionary is provided merge on the resulting object
+def test_class_dict_merge_to_instance(generator_sub_config):
+    config_dict_var = {"dict_a": "test_val", "dict_c": "test_val"}
+    generator_sub_config.generators["mock"]["class_dict_var"] = config_dict_var
+    m = mockConfigurable(config_root=generator_sub_config)
+    assert m.class_dict_var == m.DEFAULT_PARAMS["class_dict_var"] | config_dict_var
+    assert m.class_dict_var["dict_a"] == config_dict_var["dict_a"]
+    assert m.class_dict_var["dict_c"] == config_dict_var["dict_c"]
 
 
 # when a default parameter is provided and not config_root set on the resulting object


### PR DESCRIPTION
Fix #672 
Fix #589

Provide huggingface `Pipeline` and `LLaVA` configuration values as `hf_args` that can be passed via the `yaml` or `json` generator configuration paths.

* do not override config deprefix_prompt
* improve code reuse
  * consolidate `__init__` where possible
  * shift generator or model object creation to `_load_client()`
  * Wrap errors as `GarakException` vs `Exception`
* crude implementation of limitation on parallel generator call
* add torch `mps` support
  * detect `cuda` vs `mps` vs `cpu` in a common way
  * guard import of OptimimPipeline
* enable hf model or pipeline config in hf_args
  * support all generic `pipeline` args at all times
  * adds `do_sample` when `model` is a parameter to the `Callable`
  * adds `low_cpu_mem_usage` and all `pipeline` arguments for `Callables` without `model`
  * consolidates optimal device selection & set when not provided by config

~~Note: While `hugggingface.Model` not extends `Pipeline` due to how the model is loaded the only `hf_arg` currently passed is `hf_args["device"]` more work is needed to support more~~

Testing of each class type is needed and should likely be baselined code prior to #711 as few recommended possible testing configurations used on various hardware:
```
python -m garak -m huggingface.Model -n meta-llama/Llama-2-7b-chat-hf --config fast -g 1
python -m garak --model_type huggingface --model_name gpt2 --config fast -g 1
python -m garak --model_type huggingface.LLaVA --model_name llava-hf/llava-v1.6-mistral-7b-hf -p visual_jailbreak.FigStepTiny
```

Example configuration yaml:
```
plugins:
  generators:
    huggingface:
      hf_args:
        torch_dtype: float16
      Pipeline:
        hf_args:
            device: cuda
```

When no `device` is specified by configuration `garak` will now select `cuda` / `mps` / `cpu` depending on environment availability. 