### PR TITLE
Handle openai 400 errors more gracefully

### DIFF
--- a/garak/generators/nim.py
+++ b/garak/generators/nim.py
@@ -63,7 +63,9 @@ class NVOpenAIChat(OpenAICompatible):
     def _call_model(
         self, prompt: str | List[dict], generations_this_call: int = 1
     ) -> List[Union[str, None]]:
-        assert generations_this_call == 1, "n>1 is not supported"
+        assert (
+            generations_this_call == 1
+        ), "generations_per_call / n > 1 is not supported"
         return super()._call_model(prompt, generations_this_call)
 
 

--- a/garak/generators/openai.py
+++ b/garak/generators/openai.py
@@ -198,18 +198,23 @@ class OpenAICompatible(Generator):
                 logging.error(msg)
                 print(msg)
                 return list()
-            response = self.generator.create(
-                model=self.name,
-                messages=messages,
-                temperature=self.temperature,
-                top_p=self.top_p,
-                n=generations_this_call,
-                stop=self.stop,
-                max_tokens=self.max_tokens,
-                presence_penalty=self.presence_penalty,
-                frequency_penalty=self.frequency_penalty,
-            )
-            return [c.message.content for c in response.choices]
+            try:
+                response = self.generator.create(
+                    model=self.name,
+                    messages=messages,
+                    temperature=self.temperature,
+                    top_p=self.top_p,
+                    n=generations_this_call,
+                    stop=self.stop,
+                    max_tokens=self.max_tokens,
+                    presence_penalty=self.presence_penalty,
+                    frequency_penalty=self.frequency_penalty,
+                )
+                return [c.message.content for c in response.choices]
+            except openai.BadRequestError:
+                msg = "Bad request: " + str(repr(prompt))
+                logging.error(msg)
+                return [None]
 
         else:
             raise ValueError(


### PR DESCRIPTION
Catch `openai.BadRequestError` & log, return `None`