### PR TITLE
remove extraneous default params for nims that expect conservative pa…

### DIFF
--- a/garak/generators/nim.py
+++ b/garak/generators/nim.py
@@ -42,6 +42,9 @@ class NVOpenAIChat(OpenAICompatible):
     active = True
     supports_multiple_generations = False
     generator_family_name = "NIM"
+    frequency_penalty = None
+    presence_penalty = None
+    blocked_params = {"n"}
 
     timeout = 60
 
@@ -66,6 +69,8 @@ class NVOpenAIChat(OpenAICompatible):
         assert (
             generations_this_call == 1
         ), "generations_per_call / n > 1 is not supported"
+        self.presence_penalty = None
+        self.frequency_penalty = None
         return super()._call_model(prompt, generations_this_call)
 
 

--- a/garak/generators/nim.py
+++ b/garak/generators/nim.py
@@ -38,11 +38,11 @@ class NVOpenAIChat(OpenAICompatible):
         "top_p": 0.7,
         "top_k": 0,  # top_k is hard set to zero as of 24.04.30
         "uri": "https://integrate.api.nvidia.com/v1/",
+        "suppressed_params": {"n", "frequency_penalty", "presence_penalty"},
     }
     active = True
     supports_multiple_generations = False
     generator_family_name = "NIM"
-    suppressed_params = {"n", "frequency_penalty", "presence_penalty"}
 
     timeout = 60
 

--- a/garak/generators/nim.py
+++ b/garak/generators/nim.py
@@ -42,9 +42,7 @@ class NVOpenAIChat(OpenAICompatible):
     active = True
     supports_multiple_generations = False
     generator_family_name = "NIM"
-    frequency_penalty = None
-    presence_penalty = None
-    suppressed_params = {"n"}
+    suppressed_params = {"n", "frequency_penalty", "presence_penalty"}
 
     timeout = 60
 

--- a/garak/generators/nim.py
+++ b/garak/generators/nim.py
@@ -33,7 +33,7 @@ class NVOpenAIChat(OpenAICompatible):
     # per https://docs.nvidia.com/ai-enterprise/nim-llm/latest/openai-api.html
     # 2024.05.02, `n>1` is not supported
     ENV_VAR = "NIM_API_KEY"
-    DEFAULT_PARAMS = {
+    DEFAULT_PARAMS = OpenAICompatible.DEFAULT_PARAMS | {
         "temperature": 0.1,
         "top_p": 0.7,
         "top_k": 0,  # top_k is hard set to zero as of 24.04.30
@@ -44,7 +44,7 @@ class NVOpenAIChat(OpenAICompatible):
     generator_family_name = "NIM"
     frequency_penalty = None
     presence_penalty = None
-    blocked_params = {"n"}
+    suppressed_params = {"n"}
 
     timeout = 60
 

--- a/garak/generators/nim.py
+++ b/garak/generators/nim.py
@@ -67,8 +67,6 @@ class NVOpenAIChat(OpenAICompatible):
         assert (
             generations_this_call == 1
         ), "generations_per_call / n > 1 is not supported"
-        self.presence_penalty = None
-        self.frequency_penalty = None
         return super()._call_model(prompt, generations_this_call)
 
 

--- a/garak/generators/openai.py
+++ b/garak/generators/openai.py
@@ -99,8 +99,6 @@ class OpenAICompatible(Generator):
         "presence_penalty": 0.0,
         "stop": ["#", ";"],
         "suppressed_params": set(),
-        "generations": 10,
-        "suppressed_params": set(),
     }
 
     # avoid attempt to pickle the client attribute

--- a/garak/generators/openai.py
+++ b/garak/generators/openai.py
@@ -99,9 +99,10 @@ class OpenAICompatible(Generator):
         "presence_penalty": 0.0,
         "stop": ["#", ";"],
         "blocked_params": set(),
+        "generations": 10,
     }
 
-    blocked_params = set()
+    suppressed_params = set()
 
     # avoid attempt to pickle the client attribute
     def __getstate__(self) -> object:
@@ -159,6 +160,23 @@ class OpenAICompatible(Generator):
         if self.client is None:
             # reload client once when consuming the generator
             self._load_client()
+
+        create_args = {
+            "model": self.name,
+            "temperature": self.temperature,
+            "max_tokens": self.max_tokens,
+            "n": generations_this_call,
+            "top_p": self.top_p,
+            "frequency_penalty": self.frequency_penalty,
+            "presence_penalty": self.presence_penalty,
+            "stop": self.stop,
+        }
+
+        create_args = {k: v for k, v in create_args.items() if v is not None}
+        create_args = {
+            k: v for k, v in create_args.items() if k not in self.suppressed_params
+        }
+
         if self.generator == self.client.completions:
             if not isinstance(prompt, str):
                 msg = (
@@ -169,21 +187,7 @@ class OpenAICompatible(Generator):
                 print(msg)
                 return list()
 
-            create_args = {
-                "model": self.name,
-                "prompt": prompt,
-                "temperature": self.temperature,
-                "max_tokens": self.max_tokens,
-                "n": generations_this_call,
-                "top_p": self.top_p,
-                "frequency_penalty": self.frequency_penalty,
-                "presence_penalty": self.presence_penalty,
-                "stop": self.stop,
-            }
-            create_args = {k: v for k, v in create_args.items() if v is not None}
-            create_args = {
-                k: v for k, v in create_args.items() if k not in self.blocked_params
-            }
+            create_args["prompt"] = prompt
 
             response = self.generator.create(**create_args)
             return [c.text for c in response.choices]
@@ -202,22 +206,7 @@ class OpenAICompatible(Generator):
                 print(msg)
                 return list()
             try:
-                create_args = {
-                    "model": self.name,
-                    "messages": messages,
-                    "temperature": self.temperature,
-                    "top_p": self.top_p,
-                    "n": generations_this_call,
-                    "stop": self.stop,
-                    "max_tokens": self.max_tokens,
-                    "presence_penalty": self.presence_penalty,
-                    "frequency_penalty": self.frequency_penalty,
-                }
-                create_args = {k: v for k, v in create_args.items() if v is not None}
-                create_args = {
-                    k: v for k, v in create_args.items() if k not in self.blocked_params
-                }
-
+                create_args["messages"] = messages
                 response = self.generator.create(**create_args)
 
                 return [c.message.content for c in response.choices]

--- a/garak/generators/openai.py
+++ b/garak/generators/openai.py
@@ -169,10 +169,7 @@ class OpenAICompatible(Generator):
             "stop": self.stop,
         }
 
-        create_args = {k: v for k, v in create_args.items() if v is not None}
-        create_args = {
-            k: v for k, v in create_args.items() if k not in self.suppressed_params
-        }
+        create_args = {k: v for k, v in create_args.items() if v is not None and k not in self.suppressed_params}
 
         if self.generator == self.client.completions:
             if not isinstance(prompt, str):

--- a/garak/generators/openai.py
+++ b/garak/generators/openai.py
@@ -101,11 +101,6 @@ class OpenAICompatible(Generator):
         "blocked_params": set(),
     }
 
-    temperature = 0.7
-    top_p = 1.0
-    frequency_penalty = 0.0
-    presence_penalty = 0.0
-    stop = ["#", ";"]
     blocked_params = set()
 
     # avoid attempt to pickle the client attribute

--- a/garak/generators/openai.py
+++ b/garak/generators/openai.py
@@ -98,11 +98,10 @@ class OpenAICompatible(Generator):
         "frequency_penalty": 0.0,
         "presence_penalty": 0.0,
         "stop": ["#", ";"],
-        "blocked_params": set(),
+        "suppressed_params": set(),
         "generations": 10,
+        "suppressed_params": set(),
     }
-
-    suppressed_params = set()
 
     # avoid attempt to pickle the client attribute
     def __getstate__(self) -> object:

--- a/garak/generators/openai.py
+++ b/garak/generators/openai.py
@@ -98,6 +98,7 @@ class OpenAICompatible(Generator):
         "frequency_penalty": 0.0,
         "presence_penalty": 0.0,
         "stop": ["#", ";"],
+        "blocked_params": set(),
     }
 
     temperature = 0.7
@@ -105,6 +106,7 @@ class OpenAICompatible(Generator):
     frequency_penalty = 0.0
     presence_penalty = 0.0
     stop = ["#", ";"]
+    blocked_params = set()
 
     # avoid attempt to pickle the client attribute
     def __getstate__(self) -> object:
@@ -172,17 +174,23 @@ class OpenAICompatible(Generator):
                 print(msg)
                 return list()
 
-            response = self.generator.create(
-                model=self.name,
-                prompt=prompt,
-                temperature=self.temperature,
-                max_tokens=self.max_tokens,
-                n=generations_this_call,
-                top_p=self.top_p,
-                frequency_penalty=self.frequency_penalty,
-                presence_penalty=self.presence_penalty,
-                stop=self.stop,
-            )
+            create_args = {
+                "model": self.name,
+                "prompt": prompt,
+                "temperature": self.temperature,
+                "max_tokens": self.max_tokens,
+                "n": generations_this_call,
+                "top_p": self.top_p,
+                "frequency_penalty": self.frequency_penalty,
+                "presence_penalty": self.presence_penalty,
+                "stop": self.stop,
+            }
+            create_args = {k: v for k, v in create_args.items() if v is not None}
+            create_args = {
+                k: v for k, v in create_args.items() if k not in self.blocked_params
+            }
+
+            response = self.generator.create(**create_args)
             return [c.text for c in response.choices]
 
         elif self.generator == self.client.chat.completions:
@@ -199,17 +207,24 @@ class OpenAICompatible(Generator):
                 print(msg)
                 return list()
             try:
-                response = self.generator.create(
-                    model=self.name,
-                    messages=messages,
-                    temperature=self.temperature,
-                    top_p=self.top_p,
-                    n=generations_this_call,
-                    stop=self.stop,
-                    max_tokens=self.max_tokens,
-                    presence_penalty=self.presence_penalty,
-                    frequency_penalty=self.frequency_penalty,
-                )
+                create_args = {
+                    "model": self.name,
+                    "messages": messages,
+                    "temperature": self.temperature,
+                    "top_p": self.top_p,
+                    "n": generations_this_call,
+                    "stop": self.stop,
+                    "max_tokens": self.max_tokens,
+                    "presence_penalty": self.presence_penalty,
+                    "frequency_penalty": self.frequency_penalty,
+                }
+                create_args = {k: v for k, v in create_args.items() if v is not None}
+                create_args = {
+                    k: v for k, v in create_args.items() if k not in self.blocked_params
+                }
+
+                response = self.generator.create(**create_args)
+
                 return [c.message.content for c in response.choices]
             except openai.BadRequestError:
                 msg = "Bad request: " + str(repr(prompt))

--- a/tests/generators/test_nim.py
+++ b/tests/generators/test_nim.py
@@ -52,3 +52,21 @@ def test_nim_parallel_attempts():
 def test_nim_hf_detector():
     garak.cli.main("-m nim -p lmrc.Bullying -g 1 -n google/gemma-2b".split())
     assert True
+
+
+@pytest.mark.skipif(
+    os.getenv(NVOpenAIChat.ENV_VAR, None) is None,
+    reason=f"NIM API key is not set in {NVOpenAIChat.ENV_VAR}",
+)
+def test_nim_conservative_api():  # extraneous params can throw 422
+    g = NVOpenAIChat(name="nvidia/nemotron-4-340b-instruct")
+    result = g._call_model("this is a test", generations_this_call=1)
+    assert isinstance(result, list), "NIM _call_model should return a list"
+    assert len(result) == 1, "NIM _call_model result list should have one item"
+    assert isinstance(result[0], str), "NIM _call_model should return a list"
+    result = g.generate("this is a test", generations_this_call=1)
+    assert isinstance(result, list), "NIM generate() should return a list"
+    assert (
+        len(result) == 1
+    ), "NIM generate() result list should have one item when generations_this_call=1"
+    assert isinstance(result[0], str), "NIM generate() should return a list"


### PR DESCRIPTION
resolves #748

* add a "blocked params" value to `OpenAICompatible` so we can control verbosity of payloads
* strip out `None`s from OpenAI API payloads
* force unset defaults for some params in `nim`

one question - why are these defaults defined twice?

```
    # template defaults optionally override when extending
    DEFAULT_PARAMS = Generator.DEFAULT_PARAMS | {
        "temperature": 0.7,
        "top_p": 1.0,
        "frequency_penalty": 0.0,
        "presence_penalty": 0.0,
        "stop": ["#", ";"],
        "blocked_params": set(),
    }

    temperature = 0.7
    top_p = 1.0
    frequency_penalty = 0.0
    presence_penalty = 0.0
    stop = ["#", ";"]
    blocked_params = set()
```

