### PR TITLE
enable nested setting of plugin configs

### DIFF
--- a/garak/_config.py
+++ b/garak/_config.py
@@ -7,6 +7,7 @@
 
 # logging should be set up before config is loaded
 
+from collections import defaultdict
 from dataclasses import dataclass
 import importlib
 import logging
@@ -60,11 +61,13 @@ system = GarakSubConfig()
 run = GarakSubConfig()
 plugins = GarakSubConfig()
 reporting = GarakSubConfig()
-plugins.probes = {}
-plugins.generators = {}
-plugins.detectors = {}
-plugins.buffs = {}
-plugins.harnesses = {}
+
+nested_dict = lambda: defaultdict(nested_dict)
+plugins.probes = nested_dict()
+plugins.generators = nested_dict()
+plugins.detectors = nested_dict()
+plugins.buffs = nested_dict()
+plugins.harnesses = nested_dict()
 reporting.taxonomy = None  # set here to enable report_digest to be called directly
 
 buffmanager = BuffManager()


### PR DESCRIPTION
tired:

```
    from garak import _config
    _config.plugins.generators["nvcf"] = {}
    _config.plugins.generators["nvcf"]["NvcfChat"] = {}
    _config.plugins.generators["nvcf"]["NvcfChat"]["name"] = "placeholder name"
    _config.plugins.generators["nvcf"]["NvcfChat"]["api_key"] = "placeholder key"
```

wired:
```
    from garak import _config
    _config.plugins.generators["nvcf"]["NvcfChat"]["name"] = "placeholder name"
    _config.plugins.generators["nvcf"]["NvcfChat"]["api_key"] = "placeholder key"
```
