### PR TITLE
enhancement: enable lazy setting of nested dicts

### DIFF
--- a/garak/_config.py
+++ b/garak/_config.py
@@ -7,6 +7,7 @@
 
 # logging should be set up before config is loaded
 
+from collections import defaultdict
 from dataclasses import dataclass
 import importlib
 import logging
@@ -60,11 +61,13 @@ system = GarakSubConfig()
 run = GarakSubConfig()
 plugins = GarakSubConfig()
 reporting = GarakSubConfig()
-plugins.probes = {}
-plugins.generators = {}
-plugins.detectors = {}
-plugins.buffs = {}
-plugins.harnesses = {}
+
+nested_dict = lambda: defaultdict(nested_dict)
+plugins.probes = nested_dict()
+plugins.generators = nested_dict()
+plugins.detectors = nested_dict()
+plugins.buffs = nested_dict()
+plugins.harnesses = nested_dict()
 reporting.taxonomy = None  # set here to enable report_digest to be called directly
 
 buffmanager = BuffManager()

--- a/garak/_config.py
+++ b/garak/_config.py
@@ -90,7 +90,7 @@ def _set_settings(config_obj, settings_obj: dict):
 def _combine_into(d: dict, combined: dict) -> None:
     for k, v in d.items():
         if isinstance(v, dict):
-            _combine_into(v, combined.setdefault(k, {}))
+            _combine_into(v, combined.setdefault(k, nested_dict))
         else:
             combined[k] = v
     return combined
@@ -99,7 +99,7 @@ def _combine_into(d: dict, combined: dict) -> None:
 def _load_yaml_config(settings_filenames) -> dict:
     global config_files
     config_files += settings_filenames
-    config = {}
+    config = nested_dict()
     for settings_filename in settings_filenames:
         with open(settings_filename, encoding="utf-8") as settings_file:
             settings = yaml.safe_load(settings_file)

--- a/garak/_config.py
+++ b/garak/_config.py
@@ -16,6 +16,8 @@ import pathlib
 from typing import List
 import yaml
 
+DICT_CONFIG_AFTER_LOAD = False
+
 version = -1  # eh why this is here? hm. who references it
 
 system_params = (
@@ -55,7 +57,6 @@ class TransientConfig(GarakSubConfig):
     starttime_iso = None
 
 
-
 transient = TransientConfig()
 
 system = GarakSubConfig()
@@ -63,16 +64,19 @@ run = GarakSubConfig()
 plugins = GarakSubConfig()
 reporting = GarakSubConfig()
 
+
 def _lock_config_as_dict():
     global plugins
-    for plugin_type in ('probes', 'generators', 'buffs', 'detectors', 'harnesses'):
+    for plugin_type in ("probes", "generators", "buffs", "detectors", "harnesses"):
         setattr(plugins, plugin_type, _crystallise(getattr(plugins, plugin_type)))
+
 
 def _crystallise(d):
     for k in d.keys():
         if isinstance(d[k], defaultdict):
             d[k] = _crystallise(d[k])
     return dict(d)
+
 
 nested_dict = lambda: defaultdict(nested_dict)
 
@@ -171,7 +175,8 @@ def load_config(
 
     logging.debug("Loading configs from: %s", ",".join(settings_files))
     _store_config(settings_files=settings_files)
-    _lock_config_as_dict()
+    if DICT_CONFIG_AFTER_LOAD:
+        _lock_config_as_dict()
     loaded = True
 
 

--- a/garak/_config.py
+++ b/garak/_config.py
@@ -90,7 +90,7 @@ def _set_settings(config_obj, settings_obj: dict):
 def _combine_into(d: dict, combined: dict) -> None:
     for k, v in d.items():
         if isinstance(v, dict):
-            _combine_into(v, combined.setdefault(k, nested_dict))
+            _combine_into(v, combined.setdefault(k, nested_dict()))
         else:
             combined[k] = v
     return combined

--- a/garak/_config.py
+++ b/garak/_config.py
@@ -55,6 +55,7 @@ class TransientConfig(GarakSubConfig):
     starttime_iso = None
 
 
+
 transient = TransientConfig()
 
 system = GarakSubConfig()
@@ -62,7 +63,19 @@ run = GarakSubConfig()
 plugins = GarakSubConfig()
 reporting = GarakSubConfig()
 
+def _lock_config_as_dict():
+    global plugins
+    for plugin_type in ('probes', 'generators', 'buffs', 'detectors', 'harnesses'):
+        setattr(plugins, plugin_type, _crystallise(getattr(plugins, plugin_type)))
+
+def _crystallise(d):
+    for k in d.keys():
+        if isinstance(d[k], defaultdict):
+            d[k] = _crystallise(d[k])
+    return dict(d)
+
 nested_dict = lambda: defaultdict(nested_dict)
+
 plugins.probes = nested_dict()
 plugins.generators = nested_dict()
 plugins.detectors = nested_dict()
@@ -158,6 +171,7 @@ def load_config(
 
     logging.debug("Loading configs from: %s", ",".join(settings_files))
     _store_config(settings_files=settings_files)
+    _lock_config_as_dict()
     loaded = True
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -623,3 +623,8 @@ def test_report_prefix_with_hitlog_no_explode():
     assert os.path.isfile("kjsfhgkjahpsfdg.report.jsonl")
     assert os.path.isfile("kjsfhgkjahpsfdg.report.html")
     assert os.path.isfile("kjsfhgkjahpsfdg.hitlog.jsonl")
+
+
+def test_nested():
+    _config.plugins.generators["a"]["b"]["c"]["d"] = "e"
+    assert _config.plugins.generators["a"]["b"]["c"]["d"] == "e"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -625,5 +625,7 @@ def test_report_prefix_with_hitlog_no_explode():
 
 
 def test_nested():
+    importlib.reload(_config)
+
     _config.plugins.generators["a"]["b"]["c"]["d"] = "e"
     assert _config.plugins.generators["a"]["b"]["c"]["d"] == "e"


### PR DESCRIPTION
tired:

```
    from garak import _config
    _config.plugins.generators["nvcf"] = {}
    _config.plugins.generators["nvcf"]["NvcfChat"] = {}
    _config.plugins.generators["nvcf"]["NvcfChat"]["name"] = "placeholder name"
    _config.plugins.generators["nvcf"]["NvcfChat"]["api_key"] = "placeholder key"
```

wired:
```
    from garak import _config
    _config.plugins.generators["nvcf"]["NvcfChat"]["name"] = "placeholder name"
    _config.plugins.generators["nvcf"]["NvcfChat"]["api_key"] = "placeholder key"
```

continuation of #773 