### PR TITLE
don't skip listing probes in 100%-pass-rate modules

### DIFF
--- a/garak/__main__.py
+++ b/garak/__main__.py
@@ -10,4 +10,5 @@ def main():
 
 
 if __name__ == "__main__":
+    sys.stdout.reconfigure(encoding="utf-8")
     main()

--- a/garak/analyze/report_digest.py
+++ b/garak/analyze/report_digest.py
@@ -15,6 +15,8 @@ import jinja2
 
 from garak import _config
 
+SHOW_100_PERCENT_MODULES = True
+
 templateLoader = jinja2.FileSystemLoader(
     searchpath=_config.transient.basedir / "analyze" / "templates"
 )
@@ -174,7 +176,7 @@ def compile_digest(report_path, taxonomy=_config.reporting.taxonomy):
             }
         )
 
-        if top_score < 100.0:
+        if SHOW_100_PERCENT_MODULES or top_score < 100.0:
             res = cursor.execute(
                 f"select probe_module, probe_class, avg(score)*100 as s from results where probe_group='{probe_group}' group by probe_class order by s asc, probe_class asc;"
             )
@@ -231,4 +233,4 @@ if __name__ == "__main__":
     if len(sys.argv) == 3:
         taxonomy = sys.argv[2]
     digest_content = compile_digest(report_path, taxonomy=taxonomy)
-    print(digest_content.encode("utf-8"))
+    print(digest_content)

--- a/garak/analyze/report_digest.py
+++ b/garak/analyze/report_digest.py
@@ -229,6 +229,7 @@ def compile_digest(report_path, taxonomy=_config.reporting.taxonomy):
 
 
 if __name__ == "__main__":
+    sys.stdout.reconfigure(encoding="utf-8")
     report_path = sys.argv[1]
     taxonomy = None
     if len(sys.argv) == 3:

--- a/garak/analyze/report_digest.py
+++ b/garak/analyze/report_digest.py
@@ -15,7 +15,8 @@ import jinja2
 
 from garak import _config
 
-SHOW_100_PERCENT_MODULES = True
+if not _config.loaded:
+    _config.load_config()
 
 templateLoader = jinja2.FileSystemLoader(
     searchpath=_config.transient.basedir / "analyze" / "templates"
@@ -176,7 +177,7 @@ def compile_digest(report_path, taxonomy=_config.reporting.taxonomy):
             }
         )
 
-        if SHOW_100_PERCENT_MODULES or top_score < 100.0:
+        if top_score < 100.0 or _config.reporting.show_100_pass_modules:
             res = cursor.execute(
                 f"select probe_module, probe_class, avg(score)*100 as s from results where probe_group='{probe_group}' group by probe_class order by s asc, probe_class asc;"
             )

--- a/garak/interactive.py
+++ b/garak/interactive.py
@@ -249,4 +249,5 @@ def interactive_mode():
 
 
 if __name__ == "__main__":
+    sys.stdout.reconfigure(encoding="utf-8")
     interactive_mode()

--- a/garak/resources/garak.core.yaml
+++ b/garak/resources/garak.core.yaml
@@ -35,3 +35,4 @@ reporting:
   report_prefix:
   taxonomy:
   report_dir: garak_runs
+  show_100_pass_modules: true

--- a/tests/analyze/test_analyze.py
+++ b/tests/analyze/test_analyze.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import os
 import subprocess
 import sys
 


### PR DESCRIPTION
resolves #725

add a constant to control whether or not modules where all probes passed at 100% still include a list of those probes