### PR TITLE
defensive coding: allow python generators more places

### DIFF
--- a/garak/attempt.py
+++ b/garak/attempt.py
@@ -1,5 +1,7 @@
 """Defines the Attempt class, which encapsulates a prompt with metadata and results"""
 
+from collections.abc import Iterable
+from types import GeneratorType
 from typing import Any, List
 import uuid
 
@@ -179,8 +181,9 @@ class Attempt:
             self._add_first_turn("user", value)
 
         elif name == "outputs":
-            if not isinstance(value, list):
-                raise TypeError("Value for attempt.outputs must be a list")
+            if not (isinstance(value, list) or isinstance(value, GeneratorType)):
+                raise TypeError("Value for attempt.outputs must be a list or generator")
+            value = list(value)
             if len(self.messages) == 0:
                 raise TypeError("A prompt must be set before outputs are given")
             # do we have only the initial prompt? in which case, let's flesh out messages a bit

--- a/garak/evaluators/base.py
+++ b/garak/evaluators/base.py
@@ -5,7 +5,7 @@ These describe evaluators for assessing detector results.
 
 import json
 import logging
-from typing import List
+from typing import Iterable
 
 from colorama import Fore, Style
 
@@ -33,18 +33,22 @@ class Evaluator:
         """
         return False  # fail everything by default
 
-    def evaluate(self, attempts: List[garak.attempt.Attempt]) -> None:
+    def evaluate(self, attempts: Iterable[garak.attempt.Attempt]) -> None:
         """
         evaluate feedback from detectors
         expects a list of attempts that correspond to one probe
         outputs results once per detector
         """
 
-        if len(attempts) == 0:
+        if isinstance(attempts, list) and len(attempts) == 0:
             logging.debug(
                 "evaluators.base.Evaluator.evaluate called with 0 attempts, expected 1+"
             )
             return
+
+        attempts = list(
+            attempts
+        )  # disprefer this but getting detector_names from first one for the loop below is a pain
 
         self.probename = attempts[0].probe_classname
         detector_names = attempts[0].detector_results.keys()

--- a/garak/harnesses/base.py
+++ b/garak/harnesses/base.py
@@ -116,7 +116,9 @@ class Harness(Configurable):
                 detector_probe_name = d.detectorname.replace("garak.detectors.", "")
                 attempt_iterator.set_description("detectors." + detector_probe_name)
                 for attempt in attempt_iterator:
-                    attempt.detector_results[detector_probe_name] = d.detect(attempt)
+                    attempt.detector_results[detector_probe_name] = list(
+                        d.detect(attempt)
+                    )
 
                     if first_detector:
                         eval_outputs += attempt.outputs

--- a/tests/test_internal_structures.py
+++ b/tests/test_internal_structures.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from collections.abc import Iterable
+import importlib
+import tempfile
+
+import pytest
+
+import garak._config
+import garak._plugins
+import garak.attempt
+import garak.generators.test
+
+# probes should be able to return a generator of attempts
+# -> probes.base.Probe._execute_all (1) should be able to consume a generator of attempts
+# generators should be able to return a generator of outputs
+# -> attempts (2) should be able to consume a generator of outputs
+# -> detectors (3) should be able to consume a generator of outputs
+# detectors should be able to return generators of results
+# -> evaluators (4) should be able to consume generators of results
+# -> attempts (5) should be able to consume generators of detector results
+# -> attempt.as_dict (6) should be able to relay a generator of detector results
+
+
+@pytest.fixture(autouse=True)
+def _config_loaded():
+    importlib.reload(garak._config)
+    garak._config.load_base_config()
+    temp_report_file = tempfile.NamedTemporaryFile(mode="w+")
+    garak._config.transient.reportfile = temp_report_file
+    garak._config.transient.report_filename = temp_report_file.name
+    yield
+    temp_report_file.close()
+
+
+def test_generator_consume_attempt_generator():
+    count = 5
+    attempts = (garak.attempt.Attempt(prompt=str(i)) for i in range(count))
+    p = garak._plugins.load_plugin("probes.test.Blank")
+    g = garak._plugins.load_plugin("generators.test.Blank")
+    p.generator = g
+    results = p._execute_all(attempts)
+
+    assert isinstance(results, Iterable), "_execute_all should return an Iterable"
+    result_len = 0
+    for _attempt in results:
+        assert isinstance(
+            _attempt, garak.attempt.Attempt
+        ), "_execute_all should return attempts"
+        result_len += 1
+    assert (
+        result_len == count
+    ), "there should be the same number of attempts in the passed generator as results returned in _execute_all"

--- a/tests/test_internal_structures.py
+++ b/tests/test_internal_structures.py
@@ -10,17 +10,16 @@ import pytest
 import garak._config
 import garak._plugins
 import garak.attempt
+import garak.evaluators.base
 import garak.generators.test
 
 # probes should be able to return a generator of attempts
 # -> probes.base.Probe._execute_all (1) should be able to consume a generator of attempts
 # generators should be able to return a generator of outputs
 # -> attempts (2) should be able to consume a generator of outputs
-# -> detectors (3) should be able to consume a generator of outputs
 # detectors should be able to return generators of results
-# -> evaluators (4) should be able to consume generators of results
-# -> attempts (5) should be able to consume generators of detector results
-# -> attempt.as_dict (6) should be able to relay a generator of detector results
+# -> evaluators (3) should be able to consume generators of results --> enforced in harness; cast to list, multiple consumption
+
 
 
 @pytest.fixture(autouse=True)
@@ -52,3 +51,13 @@ def test_generator_consume_attempt_generator():
     assert (
         result_len == count
     ), "there should be the same number of attempts in the passed generator as results returned in _execute_all"
+
+def test_attempt_outputs_can_consume_generator():
+    a = garak.attempt.Attempt(prompt="fish")
+    count = 5
+    str_iter = ("abc" for _ in range(count))
+    a.outputs = str_iter
+    outputs_list = list(a.outputs)
+    assert len(outputs_list) == count, "attempt.outputs should have same cardinality as generator used to populate it"
+    assert len(list(a.outputs)) == len(outputs_list), "attempt.outputs should have the same cardinality every time"
+


### PR DESCRIPTION
resolves #96 

* `Probe`s should be able to return a generator of attempts
* -> `probes.base.Probe._execute_all()` (1) should be able to consume a generator of attempts
* `Generator`s should be able to return a generator of outputs
* -> `attempt`s (2) should be able to consume a generator of outputs
* `Detector`s should be able to return generators of results
* -> `Evaluator¬s (3) should be able to consume generators of results --> enforced in `Harness`; cast to detect() result to list, making multiple consumption safe

