### PR TITLE
Bugfix/leakreplay output setting

### DIFF
--- a/garak/attempt.py
+++ b/garak/attempt.py
@@ -1,6 +1,5 @@
 """Defines the Attempt class, which encapsulates a prompt with metadata and results"""
 
-from collections.abc import Iterable
 from types import GeneratorType
 from typing import Any, List
 import uuid

--- a/garak/evaluators/base.py
+++ b/garak/evaluators/base.py
@@ -102,7 +102,7 @@ class Evaluator:
                                 {
                                     "goal": attempt.goal,
                                     "prompt": attempt.prompt,
-                                    "output": attempt.outputs[idx],
+                                    "output": attempt.all_outputs[idx],
                                     "trigger": trigger,
                                     "score": score,
                                     "run_id": str(_config.transient.run_id),

--- a/garak/probes/leakreplay.py
+++ b/garak/probes/leakreplay.py
@@ -64,7 +64,10 @@ class LiteratureCloze(Probe):
         return attempt
 
     def _postprocess_hook(self, attempt: Attempt) -> Attempt:
-        attempt.outputs = [re.sub("</?name>", "", o) for o in attempt.outputs]
+        for idx, thread in enumerate(attempt.messages):
+            attempt.messages[idx][-1]["content"] = re.sub(
+                "</?name>", "", thread[-1]["content"]
+            )
         return attempt
 
 

--- a/tests/probes/test_probes_leakreplay.py
+++ b/tests/probes/test_probes_leakreplay.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Portions Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import garak
+import garak._config
+import garak._plugins
+import garak.attempt
+import garak.cli
+
+
+def test_leakreplay_hitlog():
+
+    args = "-m test.Blank -p leakreplay -d always.Fail".split()
+    garak.cli.main(args)
+
+
+def test_leakreplay_output_count():
+    generations = 1
+    garak._config.load_base_config()
+    garak._config.transient.reportfile = open("/dev/null", "w+")
+    a = garak.attempt.Attempt(prompt="test")
+    p = garak._plugins.load_plugin(
+        "probes.leakreplay.LiteratureCloze80", config_root=garak._config
+    )
+    g = garak._plugins.load_plugin("generators.test.Blank", config_root=garak._config)
+    g.generations = generations
+    p.generator = g
+    results = p._execute_all([a])
+    assert len(a.all_outputs) == generations

--- a/tests/test_hitlog.py
+++ b/tests/test_hitlog.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Portions Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Portions Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 import garak

--- a/tests/test_hitlog.py
+++ b/tests/test_hitlog.py
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Portions Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import garak
+import garak.cli
+
+
+def test_hitlog_codepath():
+
+    args = "-m test.Blank -p test.Test -d always.Fail".split()
+    garak.cli.main(args)


### PR DESCRIPTION
resolves #789

any setting of `attempt.outputs` adds another output layer, so the `leakreplay`'s editing in `_postprocess_hook()` is updated to manipulate the underlying `attempt.messages` structure instead.