### PR TITLE
corrections to config format for TAP internal generators

### DIFF
--- a/garak/resources/tap/generator_utils.py
+++ b/garak/resources/tap/generator_utils.py
@@ -46,6 +46,7 @@ def load_generator(
     """
 
     config = {
+        "name": model_name,
         "generations": generations,
         "max_tokens": max_tokens,
     }
@@ -55,12 +56,22 @@ def load_generator(
 
     if model_name.lower() in hf_dict.keys():
         config["name"] = hf_dict[model_name]
-        config["device"] = device
+        config["hf_args"] = {"device": device}
 
     if model_name in supported_openai:
-        generator = OpenAIGenerator(config_root=config)
+        config_root = {
+            "generators": {
+                OpenAIGenerator.__module__.split(".")[-1]: {
+                    OpenAIGenerator.__name__: config
+                }
+            }
+        }
+        generator = OpenAIGenerator(config_root=config_root)
     elif model_name in supported_huggingface:
-        generator = Model(config_root=config)
+        config_root = {
+            "generators": {Model.__module__.split(".")[-1]: {Model.__name__: config}}
+        }
+        generator = Model(config_root=config_root)
     else:
         msg = (
             f"{model_name} is not currently supported for TAP generation. Support is available for the following "

--- a/garak/resources/tap/generator_utils.py
+++ b/garak/resources/tap/generator_utils.py
@@ -56,7 +56,6 @@ def load_generator(
 
     if model_name.lower() in hf_dict.keys():
         config["name"] = hf_dict[model_name]
-        config["hf_args"] = {"device": device}
 
     if model_name in supported_openai:
         config_root = {
@@ -68,6 +67,7 @@ def load_generator(
         }
         generator = OpenAIGenerator(config_root=config_root)
     elif model_name in supported_huggingface:
+        config["hf_args"] = {"device": device}
         config_root = {
             "generators": {Model.__module__.split(".")[-1]: {Model.__name__: config}}
         }


### PR DESCRIPTION
More cruft found from #711 & #742

* ensure `name` is set
* wrap config in required `Configurable` structure

Testing:
```
python -m garak -m huggingface.Model -n meta-llama/Llama-2-7b-chat-hf -p tap.TAP
```