### PR TITLE
suppress HF `warning`s and lower during detector model instantiation

### DIFF
--- a/garak/detectors/base.py
+++ b/garak/detectors/base.py
@@ -74,6 +74,7 @@ class HFDetector(Detector):
             AutoTokenizer,
             TextClassificationPipeline,
             set_seed,
+            logging as transformers_logging,
         )
 
         if _config.run.seed is not None:
@@ -85,6 +86,9 @@ class HFDetector(Detector):
         self.detector_model_path = model_path
         self.detector_target_class = target_class
 
+        orig_loglevel = transformers_logging.get_verbosity()
+        transformers_logging.set_verbosity_error()
+
         self.detector_model = AutoModelForSequenceClassification.from_pretrained(
             self.detector_model_path
         )
@@ -94,6 +98,8 @@ class HFDetector(Detector):
         self.detector = TextClassificationPipeline(
             model=self.detector_model, tokenizer=self.detector_tokenizer
         )
+
+        transformers_logging.set_verbosity(orig_loglevel)
 
         self.graceful_fail = False
 


### PR DESCRIPTION
avoid HF message being dumped every time the `detectors.misleading.MustContradictNLI` detector is loaded

```
Some weights of the model checkpoint at ynie/roberta-large-snli_mnli_fever_anli_R1_R2_R3-nli were not used when initializing RobertaForSequenceClassification: ['roberta.pooler.dense.bias', 'roberta.pooler.dense.weight']
- This IS expected if you are initializing RobertaForSequenceClassification from the checkpoint of a model trained on another task or with another architecture (e.g. initializing a BertForSequenceClassification model from a BertForPreTraining model).
- This IS NOT expected if you are initializing RobertaForSequenceClassification from the checkpoint of a model that you expect to be exactly identical (initializing a BertForSequenceClassification model from a BertForSequenceClassification model).
```