### PR TITLE
Flags for varying NIM seed and temperature every call 

### DIFF
--- a/garak/generators/nim.py
+++ b/garak/generators/nim.py
@@ -8,7 +8,6 @@ from typing import List, Union
 
 import openai
 
-from garak import _config
 from garak.generators.openai import OpenAICompatible
 
 

--- a/garak/generators/nim.py
+++ b/garak/generators/nim.py
@@ -73,7 +73,7 @@ class NVOpenAIChat(OpenAICompatible):
         ), "generations_per_call / n > 1 is not supported"
 
         if self.vary_seed_each_call:
-            _config.run.seed = random.randint(0, 65535)
+            self.seed = random.randint(0, 65535)
 
         if self.vary_temp_each_call:
             self.temperature = random.random()

--- a/garak/generators/openai.py
+++ b/garak/generators/openai.py
@@ -135,6 +135,7 @@ class OpenAICompatible(Generator):
         self._load_config(config_root)
         self.fullname = f"{self.generator_family_name} {self.name}"
         self.key_env_var = self.ENV_VAR
+        self.seed = config_root.run.seed
 
         self._load_client()
 
@@ -183,10 +184,8 @@ class OpenAICompatible(Generator):
             "frequency_penalty": self.frequency_penalty,
             "presence_penalty": self.presence_penalty,
             "stop": self.stop,
+            "seed": self.seed,
         }
-
-        if _config.run.seed is not None:
-            create_args["seed"] = _config.run.seed
 
         create_args = {
             k: v

--- a/garak/generators/openai.py
+++ b/garak/generators/openai.py
@@ -102,6 +102,7 @@ class OpenAICompatible(Generator):
         "top_p": 1.0,
         "frequency_penalty": 0.0,
         "presence_penalty": 0.0,
+        "seed": None,
         "stop": ["#", ";"],
         "suppressed_params": set(),
         "retry_json": True,
@@ -135,8 +136,6 @@ class OpenAICompatible(Generator):
         self._load_config(config_root)
         self.fullname = f"{self.generator_family_name} {self.name}"
         self.key_env_var = self.ENV_VAR
-        if not hasattr(self, "seed"):
-            self.seed = None
 
         self._load_client()
 

--- a/garak/generators/openai.py
+++ b/garak/generators/openai.py
@@ -135,7 +135,7 @@ class OpenAICompatible(Generator):
         self._load_config(config_root)
         self.fullname = f"{self.generator_family_name} {self.name}"
         self.key_env_var = self.ENV_VAR
-        if "seed" not in dir(self):
+        if not hasattr(self, "seed"):
             self.seed = None
 
         self._load_client()

--- a/garak/generators/openai.py
+++ b/garak/generators/openai.py
@@ -135,7 +135,8 @@ class OpenAICompatible(Generator):
         self._load_config(config_root)
         self.fullname = f"{self.generator_family_name} {self.name}"
         self.key_env_var = self.ENV_VAR
-        self.seed = config_root.run.seed
+        if "seed" not in dir(self):
+            self.seed = None
 
         self._load_client()
 

--- a/garak/generators/openai.py
+++ b/garak/generators/openai.py
@@ -25,9 +25,9 @@ from garak.generators.base import Generator
 # lists derived from https://platform.openai.com/docs/models
 chat_models = (
     "gpt-4",  # links to latest version
-    "gpt-4-turbo", # links to latest version
-    "gpt-4o", # links to latest version
-    "gpt-4o-mini", # links to latest version
+    "gpt-4-turbo",  # links to latest version
+    "gpt-4o",  # links to latest version
+    "gpt-4o-mini",  # links to latest version
     "gpt-4-turbo-preview",
     "gpt-3.5-turbo",  # links to latest version
     "gpt-4-32k",
@@ -184,6 +184,9 @@ class OpenAICompatible(Generator):
             "presence_penalty": self.presence_penalty,
             "stop": self.stop,
         }
+
+        if _config.run.seed is not None:
+            create_args["seed"] = _config.run.seed
 
         create_args = {
             k: v


### PR DESCRIPTION
NIMs tend to always give the same response for a given config. This breaks the method of using `generations > 1` for stochastic testing. This PR adds two options to make sure the random seed or temperature are varied every call. Not all existing NIMs respect the values in these fields, so the options are both set `True` by default, to give the best chances of `generations > 1` working as expected (i.e. generating multiple potentially different responses).