### PR TITLE
make default regex `raw` to remove python 3.12 warnings

### DIFF
--- a/garak/probes/atkgen.py
+++ b/garak/probes/atkgen.py
@@ -60,7 +60,7 @@ class Tox(Probe):
             "hf_args": {"device": "cpu", "torch_dtype": "float32"}
         },  # defer acceleration devices to model under test unless overriden
         "red_team_prompt_template": "<|input|>[query]<|response|>",
-        "red_team_postproc_rm_regex": "\<\|.*",
+        "red_team_postproc_rm_regex": r"\<\|.*",
         "use_only_first_sent": True,  # should we only consider the first sentence of the target's response?
     }
 


### PR DESCRIPTION
Fix #802

Update regex default string to remove python 3.12 warning:

Using Python 3.12+

Before:
```
🦜 loading generator: Test: Lorem Ipsum
📜 reporting to /Users/jemartin/.local/share/garak/garak_runs/garak.3d0391eb-c705-4964-a1b9-01e413d23d86.report.jsonl
🕵️  queue of probes: atkgen.Tox
/Users/jemartin/Projects/nvidia/garak/garak/probes/atkgen.py:63: SyntaxWarning: invalid escape sequence '\<'
  "red_team_postproc_rm_regex": "\<\|.*",
🔴🪖  🦜 loading generator: Hugging Face 🤗 pipeline: leondz/artgpt2tox
atkgen.Tox                                                                toxicity.ToxicCommentModel: PASS  ok on    5/   5
📜 report closed :) /Users/jemartin/.local/share/garak/garak_runs/garak.3d0391eb-c705-4964-a1b9-01e413d23d86.report.jsonl
📜 report html summary being written to /Users/jemartin/.local/share/garak/garak_runs/garak.3d0391eb-c705-4964-a1b9-01e413d23d86.report.html
✔️  garak run complete in 15.74s
```

After:
```
garak LLM vulnerability scanner v0.9.0.14.post1 ( https://github.com/leondz/garak ) at 2024-07-30T15:55:00.122626
🦜 loading generator: Test: Lorem Ipsum
📜 reporting to /Users/jemartin/.local/share/garak/garak_runs/garak.87a12a50-d726-46fe-b0eb-c0e28f30cc9e.report.jsonl
🕵️  queue of probes: atkgen.Tox
🔴🪖  🦜 loading generator: Hugging Face 🤗 pipeline: leondz/artgpt2tox
atkgen.Tox                                                                toxicity.ToxicCommentModel: PASS  ok on    5/   5
📜 report closed :) /Users/jemartin/.local/share/garak/garak_runs/garak.87a12a50-d726-46fe-b0eb-c0e28f30cc9e.report.jsonl
📜 report html summary being written to /Users/jemartin/.local/share/garak/garak_runs/garak.87a12a50-d726-46fe-b0eb-c0e28f30cc9e.report.html
✔️  garak run complete in 33.71s
```