### PR TITLE
enable HFDetector model configuration with hf_args

### DIFF
--- a/garak/detectors/base.py
+++ b/garak/detectors/base.py
@@ -71,7 +71,7 @@ class HFDetector(Detector, HFCompatible):
 
     DEFAULT_PARAMS = Detector.DEFAULT_PARAMS | {"hf_args": {"device": "cpu"}}
 
-    def __init__(self, model_path, target_class, config_root=_config):
+    def __init__(self, config_root=_config):
         from transformers import (
             AutoConfig,
             AutoModelForSequenceClassification,
@@ -84,17 +84,14 @@ class HFDetector(Detector, HFCompatible):
         if _config.run.seed is not None:
             set_seed(_config.run.seed)
 
-        self.name = f"HF: {model_path}"
         super().__init__(config_root=config_root)
+        self.name = f"{self.__class__.__name__}: {self.detector_model_path}"
 
         import torch.multiprocessing as mp
 
         mp.set_start_method("spawn", force=True)
 
         self.device = self._select_hf_device()
-
-        self.detector_model_path = model_path
-        self.detector_target_class = target_class
 
         orig_loglevel = transformers_logging.get_verbosity()
         transformers_logging.set_verbosity_error()

--- a/garak/detectors/base.py
+++ b/garak/detectors/base.py
@@ -11,6 +11,7 @@ from colorama import Fore, Style
 
 from garak import _config
 from garak.configurable import Configurable
+from garak.generators.huggingface import HFCompatible
 import garak.attempt
 
 
@@ -65,11 +66,14 @@ class Detector(Configurable):
         return [0.5] * len(attempt.all_outputs)
 
 
-class HFDetector(Detector):
+class HFDetector(Detector, HFCompatible):
     """Detector using a Hugging Face model"""
+
+    DEFAULT_PARAMS = Detector.DEFAULT_PARAMS | {"hf_args": {"device": "cpu"}}
 
     def __init__(self, model_path, target_class, config_root=_config):
         from transformers import (
+            AutoConfig,
             AutoModelForSequenceClassification,
             AutoTokenizer,
             TextClassificationPipeline,
@@ -83,15 +87,31 @@ class HFDetector(Detector):
         self.name = f"HF: {model_path}"
         super().__init__(config_root=config_root)
 
+        import torch.multiprocessing as mp
+
+        mp.set_start_method("spawn", force=True)
+
+        self.device = self._select_hf_device()
+
         self.detector_model_path = model_path
         self.detector_target_class = target_class
 
         orig_loglevel = transformers_logging.get_verbosity()
         transformers_logging.set_verbosity_error()
 
-        self.detector_model = AutoModelForSequenceClassification.from_pretrained(
-            self.detector_model_path
+        model_kwargs = self._gather_hf_params(
+            hf_constructor=AutoConfig.from_pretrained
+        )  # will defer to device_map if device map was `auto` may not match self.device
+
+        self.config = AutoConfig.from_pretrained(
+            self.detector_model_path, **model_kwargs
         )
+
+        self.config.init_device = self.device
+
+        self.detector_model = AutoModelForSequenceClassification.from_pretrained(
+            self.detector_model_path, config=self.config
+        ).to(self.device)
         self.detector_tokenizer = AutoTokenizer.from_pretrained(
             self.detector_model_path
         )

--- a/garak/detectors/misleading.py
+++ b/garak/detectors/misleading.py
@@ -82,18 +82,23 @@ class MustContradictNLI(HFDetector):
                 truncation=True,
             )
             input_ids = (
-                torch.Tensor(tokenized_input_seq_pair["input_ids"]).long().unsqueeze(0)
+                torch.Tensor(tokenized_input_seq_pair["input_ids"])
+                .long()
+                .unsqueeze(0)
+                .to(self.device)
             )
             # remember bart doesn't have 'token_type_ids', remove the line below if you are using bart.
             token_type_ids = (
                 torch.Tensor(tokenized_input_seq_pair["token_type_ids"])
                 .long()
                 .unsqueeze(0)
+                .to(self.device)
             )
             attention_mask = (
                 torch.Tensor(tokenized_input_seq_pair["attention_mask"])
                 .long()
                 .unsqueeze(0)
+                .to(self.device)
             )
 
             outputs = self.detector_model(

--- a/garak/detectors/misleading.py
+++ b/garak/detectors/misleading.py
@@ -16,6 +16,11 @@ class MustRefuteClaimModel(HFDetector):
     A "hit" occurs when the generation fails to include a refutation.
     """
 
+    DEFAULT_PARAMS = HFDetector.DEFAULT_PARAMS | {
+        "detector_model_path": "leondz/refutation_detector_distilbert",
+        "detector_target_class": "label",
+    }
+
     description = (
         "Using leondz/refutation_detector_distilbert to detect model refutations"
     )
@@ -24,9 +29,7 @@ class MustRefuteClaimModel(HFDetector):
 
     def __init__(self, config_root=_config):
         self.tokenizer_kwargs = {"padding": True, "truncation": True, "max_length": 512}
-        super().__init__(
-            "leondz/refutation_detector_distilbert", "label", config_root=_config
-        )
+        super().__init__(config_root=_config)
 
     def detect(self, attempt: Attempt) -> List[float]:
         results = super().detect(attempt)
@@ -55,14 +58,17 @@ class MustContradictNLI(HFDetector):
     Using ynie/roberta-large-snli_mnli_fever_anli_R1_R2_R3-nli to detect model refutations
     """
 
+    DEFAULT_PARAMS = HFDetector.DEFAULT_PARAMS | {
+        "detector_model_path": "ynie/roberta-large-snli_mnli_fever_anli_R1_R2_R3-nli",
+        "detector_target_class": "label",
+    }
+
     bcp47 = "en"
     active = False  # this one is slow, skip by default
 
     def __init__(self, config_root=_config):
         self.tokenizer_kwargs = {"padding": True, "truncation": True, "max_length": 512}
         super().__init__(
-            "ynie/roberta-large-snli_mnli_fever_anli_R1_R2_R3-nli",
-            "label",
             config_root=config_root,
         )
 

--- a/garak/detectors/toxicity.py
+++ b/garak/detectors/toxicity.py
@@ -9,11 +9,14 @@ from garak.detectors.base import HFDetector
 class ToxicCommentModel(HFDetector):
     """Using martin-ha/toxic-comment-model DistilBERT to detect toxic content"""
 
+    DEFAULT_PARAMS = HFDetector.DEFAULT_PARAMS | {
+        "detector_model_path": "martin-ha/toxic-comment-model",
+        "detector_target_class": "toxic",
+    }
+
     bcp47 = "en"
     tags = ["avid-effect:ethics:E0301"]
 
     def __init__(self, config_root=_config):
-        super().__init__(
-            "martin-ha/toxic-comment-model", "toxic", config_root=config_root
-        )
+        super().__init__(config_root=config_root)
         self.tokenizer_kwargs = {"padding": True, "truncation": True, "max_length": 512}


### PR DESCRIPTION
Fix #803 

Allows `hf_args` configuration for simple `HFDetectors`:

* default to `cpu` device when no configuration is provided for the detector
* use AutoConfig to pass device to `from_pretrained`
* ensure `MustContradictNLI.detect()` places prompt for evaluation in the configured `device` space
* enable configuration of `detector_model_path` and `detector_target_class`

Example config of detector using `cuda`:
detector_cuda.yaml
```
plugins:
  detectors:
    misleading:
      MustContradictNLI:
        hf_args:
          device: cuda
```
The format above is based on `HFDetector` being a class specifically designed to use a `TextClassificationPipeline`. Is the is the approach desired or is further abstraction of `ModelAsJudge` be a goal of this revision?

Test example:
```
python -m garak -m nim -n meta/llama3-8b-instruct -p misleading.FalseAssertion50 --config detector_cuda.yaml
```
Logs and `nvidia-smi` show detector model loading in GPU.

More validation of compatible models may be desired if this pattern is determined to be a way forward.