### PR TITLE
relax litellm provider constraint

### DIFF
--- a/garak/generators/litellm.py
+++ b/garak/generators/litellm.py
@@ -125,11 +125,7 @@ class LiteLLMGenerator(Generator):
             self.name, generations=self.generations, config_root=config_root
         )
 
-        if self.provider is None:
-            raise ValueError(
-                "litellm generator needs to have a provider value configured - see docs"
-            )
-        elif (
+        if (
             self.api_key is None
         ):  # TODO: special case where api_key is not always required
             if self.provider == "openai":

--- a/garak/generators/litellm.py
+++ b/garak/generators/litellm.py
@@ -92,6 +92,7 @@ class LiteLLMGenerator(Generator):
         "generations",
         "context_len",
         "max_tokens",
+        "api_key",
         "provider",
         "api_base",
         "temperature",

--- a/garak/generators/litellm.py
+++ b/garak/generators/litellm.py
@@ -169,7 +169,11 @@ class LiteLLMGenerator(Generator):
                 custom_llm_provider=self.provider,
                 api_key=self.api_key,
             )
-        except litellm.exceptions.AuthenticationError as e:
+        except (
+            litellm.exceptions.AuthenticationError, # authentication failed for detected or passed `provider`
+            litellm.exceptions.APIConnectionError, # provider cannot be detected based on `model`
+        ) as e:
+
             raise BadGeneratorException() from e
 
         if self.supports_multiple_generations:

--- a/garak/generators/litellm.py
+++ b/garak/generators/litellm.py
@@ -151,7 +151,7 @@ class LiteLLMGenerator(Generator):
             )
         except (
             litellm.exceptions.AuthenticationError, # authentication failed for detected or passed `provider`
-            litellm.exceptions.APIConnectionError, # provider cannot be detected based on `model`
+            litellm.exceptions.BadRequestError,
         ) as e:
 
             raise BadGeneratorException() from e

--- a/garak/generators/litellm.py
+++ b/garak/generators/litellm.py
@@ -169,7 +169,7 @@ class LiteLLMGenerator(Generator):
                 custom_llm_provider=self.provider,
                 api_key=self.api_key,
             )
-        except litellm.exceptions.BadRequestError as e:
+        except litellm.exceptions.AuthenticationError as e:
             raise BadGeneratorException() from e
 
         if self.supports_multiple_generations:

--- a/garak/generators/litellm.py
+++ b/garak/generators/litellm.py
@@ -155,7 +155,7 @@ class LiteLLMGenerator(Generator):
             litellm.exceptions.BadRequestError,
         ) as e:
 
-            raise BadGeneratorException() from e
+            raise BadGeneratorException("Unrecoverable error during litellm completion see log for details") from e
 
         if self.supports_multiple_generations:
             return [c.message.content for c in response.choices]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ dependencies = [
   "ecoji>=0.1.1",
   "deepl==1.17.0",
   "fschat>=0.2.36",
-  "litellm>=1.33.8",
+  "litellm>=1.41.21",
   "jsonpath-ng>=1.6.1",
   "huggingface_hub>=0.21.0",
   'python-magic-bin>=0.4.14; sys_platform == "win32"',

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ zalgolib>=0.2.2
 ecoji>=0.1.1
 deepl==1.17.0
 fschat>=0.2.36
-litellm>=1.33.8
+litellm>=1.41.21
 jsonpath-ng>=1.6.1
 huggingface_hub>=0.21.0
 python-magic-bin>=0.4.14; sys_platform == "win32"

--- a/tests/generators/test_litellm.py
+++ b/tests/generators/test_litellm.py
@@ -46,9 +46,18 @@ def test_litellm_openrouter():
     print("test passed!")
 
 
-def test_litellm_model_non_existence():
+def test_litellm_model_detection():
+    custom_config = {
+        "generators": {
+            "litellm": {
+                "api_base": "https://garak.example.com/v1",
+            }
+        }
+    }
     model_name = "non-existent-model"
-    generator = LiteLLMGenerator(name=model_name)
+    generator = LiteLLMGenerator(name=model_name, config_root=custom_config)
     with pytest.raises(BadGeneratorException):
-        output = generator.generate("This should raise an exception")
-    assert "Exceptions on model non-existence raised by litellm should be bubbled up"
+        generator.generate("This should raise an exception")
+    generator = LiteLLMGenerator(name="openai/invalid-model", config_root=custom_config)
+    with pytest.raises(BadGeneratorException):
+        generator.generate("This should raise an exception")

--- a/tests/generators/test_litellm.py
+++ b/tests/generators/test_litellm.py
@@ -2,6 +2,7 @@ import pytest
 
 from os import getenv
 
+from garak.exception import BadGeneratorException
 from garak.generators.litellm import LiteLLMGenerator
 
 DEFAULT_GENERATIONS_QTY = 10
@@ -43,3 +44,11 @@ def test_litellm_openrouter():
     for item in output:
         assert isinstance(item, str)
     print("test passed!")
+
+
+def test_litellm_model_non_existence():
+    model_name = "non-existent-model"
+    generator = LiteLLMGenerator(name=model_name)
+    with pytest.raises(BadGeneratorException):
+        output = generator.generate("This should raise an exception")
+    assert "Exceptions on model non-existence raised by litellm should be bubbled up"


### PR DESCRIPTION
Fixing: https://github.com/leondz/garak/issues/755
- Remove provider constraint on litellm generator
- Fixes breaking garak test `test_litellm#test_litellm_openai`
- Exceptions on model non-existence raised by litellm bubbled up