### PR TITLE
fix initialization bug for kwargs in function

### DIFF
--- a/garak/generators/function.py
+++ b/garak/generators/function.py
@@ -53,7 +53,10 @@ from garak.generators.base import Generator
 class Single(Generator):
     """pass a module#function to be called as generator, with format function(prompt:str, **kwargs)->List[Union(str, None)] the parameter name `generations` is reserved"""
 
-    DEFAULT_PARAMS = {"generations": 10}
+    DEFAULT_PARAMS = {
+        "generations": 10,
+        "kwargs": {},
+    }
     doc_uri = "https://github.com/leondz/garak/issues/137"
     generator_family_name = "function"
     supports_multiple_generations = False


### PR DESCRIPTION
`Generator.function` does not define self.kwargs when we don't pass that argument progamatically in `functions.Single`.

To reproduce this error, invoke garak's cli like below
```
from garak.cli import main as garak_main
from typing import List

def generate_text(
) -> List[str]:
    return "empty str"


def main():
    args = [
        "-m",
        "function.Single",
        "-n",
        f"{__name__}#generate_text",
        "-p",
        "test.Blank"
    ]
    garak_main(args)

if __name__ == "__main__":
    main()
```
Offered fix resolves this issue.

I have read the DCO Document and I hereby sign the DCO

