### PR TITLE
fix initialization bug for kwargs in function

### DIFF
--- a/garak/generators/function.py
+++ b/garak/generators/function.py
@@ -53,7 +53,10 @@ from garak.generators.base import Generator
 class Single(Generator):
     """pass a module#function to be called as generator, with format function(prompt:str, **kwargs)->List[Union(str, None)] the parameter name `generations` is reserved"""
 
-    DEFAULT_PARAMS = {"generations": 10}
+    DEFAULT_PARAMS = {
+        "generations": 10,
+        "kwargs": {},
+    }
     doc_uri = "https://github.com/leondz/garak/issues/137"
     generator_family_name = "function"
     supports_multiple_generations = False

--- a/tests/generators/test_function.py
+++ b/tests/generators/test_function.py
@@ -1,0 +1,24 @@
+import pytest
+import re
+
+from garak import cli
+
+
+def passed_function(prompt: str, **kwargs):
+    return [None]
+
+
+def test_function_single(capsys):
+
+    args = [
+        "-m",
+        "function",
+        "-n",
+        f"{__name__}#passed_function",
+        "-p",
+        "test.Blank",
+    ]
+    cli.main(args)
+    result = capsys.readouterr()
+    last_line = result.out.strip().split("\n")[-1]
+    assert re.match("^✔️  garak run complete in [0-9]+\\.[0-9]+s$", last_line)


### PR DESCRIPTION
`Generator.function` does not define `self.kwargs` when we don't pass that argument progamatically in `function.Single`.

To reproduce this error, invoke garak's cli like below

```
from garak.cli import main as garak_main
from typing import List

def generate_text(
) -> List[str]:
    return "empty str"


def main():
    args = [
        "-m",
        "function.Single",
        "-n",
        f"{__name__}#generate_text",
        "-p",
        "test.Blank"
    ]
    garak_main(args)

if __name__ == "__main__":
    main()
```
Offered fix resolves this issue.
