### PR TITLE
add explicit permissions to commit cache updates

### DIFF
--- a/.github/workflows/maintain_cache.yml
+++ b/.github/workflows/maintain_cache.yml
@@ -12,6 +12,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  actions: write
+  contents: write
+  statuses: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Branch protections currently limit the token to read.

Specify permissions required to allow commit of cache changes in the action.


