### PR TITLE
suppress LiteLLM logging during import

### DIFF
--- a/garak/generators/litellm.py
+++ b/garak/generators/litellm.py
@@ -38,6 +38,9 @@ from typing import List, Union
 
 import backoff
 
+# Suppress log messages from LiteLLM during import
+litellm_logger = logging.getLogger("LiteLLM")
+litellm_logger.setLevel(logging.CRITICAL)
 import litellm
 
 from garak import _config


### PR DESCRIPTION
Fix #825 

This limits LiteLLM logging to suppress messages about `enterprise` features not supported in this project.