### PR TITLE
relax `--probe_tags` as supported when other probe options are passed

### DIFF
--- a/garak/cli.py
+++ b/garak/cli.py
@@ -155,7 +155,7 @@ def main(arguments=None) -> None:
         type=str,
         help="options to pass to probes, formatted as a JSON dict",
     )
-    probe_args.add_argument(
+    parser.add_argument(
         "--probe_tags",
         default=_config.run.probe_tags,
         type=str,


### PR DESCRIPTION
`--probe_tags` does no need to be mutually exclusive with `--probe_option_file` or `--probe_options`