### PR TITLE
Include max_prompts in prompt injections

### DIFF
--- a/garak/probes/promptinject.py
+++ b/garak/probes/promptinject.py
@@ -67,6 +67,7 @@ def load_data_all_attacks(self):
     self.pi_prompts = self.pi_build_prompts(prompt_config)
     for pi_prompt in self.pi_prompts:
         self.prompts.append(pi_prompt["prompt"])
+    self.max_prompts = _config.plugins.probes.get('max_probes', None) or self.max_prompts
     if self.max_prompts:
         random.seed(_config.run.seed)
         random.shuffle(self.prompts)


### PR DESCRIPTION
Somehow, the arguments that can be defined for probes via CLI, are not making it to the probes. In this case this small changes gives back the ability to set up max_probes argument. This is kind of workaround since, the value of the arguments should be automatically loaded on that stage. Nonetheless ability to set up the number of probes is useful for testing purposes.


I have read the DCO Document and I hereby sign the DCO