### PR TITLE
Surface underlying exception msg at plugin load

### DIFF
--- a/garak/_plugins.py
+++ b/garak/_plugins.py
@@ -379,7 +379,7 @@ def load_plugin(path, break_on_fail=True, config_root=_config) -> object:
     try:
         mod = importlib.import_module(module_path)
     except Exception as e:
-        logging.warning("Exception failed import of %s", module_path)
+        logging.warning("Exception failed import of %s", module_path, exc_info=e)
         if break_on_fail:
             raise ValueError("Didn't successfully import " + module_name) from e
         else:
@@ -389,12 +389,16 @@ def load_plugin(path, break_on_fail=True, config_root=_config) -> object:
         klass = getattr(mod, plugin_class_name)
         if "config_root" not in inspect.signature(klass.__init__).parameters:
             raise ConfigFailure(
-                'Incompatible function signature: "config_root" is incompatible with this plugin'
+                'Incompatible function signature: plugin must take a "config_root"'
             )
         plugin_instance = klass(config_root=config_root)
     except Exception as e:
         logging.warning(
-            "Exception instantiating %s.%s: %s", module_path, plugin_class_name, str(e)
+            "Exception instantiating %s.%s: %s",
+            module_path,
+            plugin_class_name,
+            str(e),
+            exc_info=e,
         )
         if break_on_fail:
             raise GarakException(e) from e

--- a/garak/exception.py
+++ b/garak/exception.py
@@ -36,3 +36,7 @@ class RateLimitHit(Exception):
     """Raised when a rate limiting response is returned"""
 
     pass
+
+
+class ConfigFailure(GarakException):
+    """Raised when plugin configuration fails"""


### PR DESCRIPTION
we should get the underlying exception into the log.

Example -- traces like this are unhelpful:

```
2024-08-15 17:14:15,770  INFO  probe queue: probes.topic.WordnetControversial
2024-08-15 17:14:15,770  INFO  probe init: <garak.probes.topic.WordnetControversial object at 0x744e06e45880>
2024-08-15 17:14:15,770  WARNING  Exception failed instantiation of garak.probes.topic.WordnetControversial
2024-08-15 17:14:15,770  WARNING  failed to load probe ValueError('Plugin WordnetControversial not found in probes.topic'):
2024-08-15 17:14:15,770  INFO  run complete, ending
2024-08-15 17:14:15,788  INFO  garak run complete in 3.48s
```

& there is a typically a more helpful message available:

```
(garak) 17:14:35 x1:~/dev/garak [feature/topic_probe] $ python
Python 3.12.4 | packaged by Anaconda, Inc. | (main, Jun 18 2024, 15:12:24) [GCC 11.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import garak
>>> import garak._config
>>> garak._plugins
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'garak' has no attribute '_plugins'
>>> import garak._plugins
>>> garak._plugins.lo
garak._plugins.load_plugin(  garak._plugins.logging       
>>> garak._plugins.lo
garak._plugins.load_plugin(  garak._plugins.logging       
>>> garak._plugins.load_plugin("probes.topic.WordnetControversial")
WARNING:root:Exception failed instantiation of garak.probes.topic.WordnetControversial
Traceback (most recent call last):
  File "/home/lderczynski/dev/garak/garak/_plugins.py", line 394, in load_plugin
    plugin_instance = klass(config_root=config_root)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/lderczynski/dev/garak/garak/probes/topic.py", line 93, in __init__
    wn.config.downloads_directory = _config.transient.cache_dir / "wn" / "downloads"
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: property 'downloads_directory' of 'WNConfig' object has no setter

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/lderczynski/dev/garak/garak/_plugins.py", line 400, in load_plugin
    raise ValueError(
ValueError: Plugin WordnetControversial not found in probes.topic
>>> 
```
this PR places the underlying message, in this example `AttributeError: property 'downloads_directory' of 'WNConfig' object has no setter`, into `garak.log`.