### PR TITLE
enable tokenizer customization in HFDetector

### DIFF
--- a/garak/detectors/base.py
+++ b/garak/detectors/base.py
@@ -74,7 +74,7 @@ class HFDetector(Detector, HFCompatible):
 
     DEFAULT_PARAMS = Detector.DEFAULT_PARAMS | {
         "hf_args": {"device": "cpu"},
-        "tokenizer_kwargs": {"padding": True, "truncation": True, "max_length": 512},
+        "tokenizer_kwargs": {"padding": True, "truncation": True},
     }
 
     def __init__(self, config_root=_config):

--- a/garak/detectors/base.py
+++ b/garak/detectors/base.py
@@ -72,7 +72,10 @@ class Detector(Configurable):
 class HFDetector(Detector, HFCompatible):
     """Detector using a Hugging Face model"""
 
-    DEFAULT_PARAMS = Detector.DEFAULT_PARAMS | {"hf_args": {"device": "cpu"}}
+    DEFAULT_PARAMS = Detector.DEFAULT_PARAMS | {
+        "hf_args": {"device": "cpu"},
+        "tokenizer_kwargs": {"padding": True, "truncation": True, "max_length": 512},
+    }
 
     def __init__(self, config_root=_config):
         from transformers import (

--- a/garak/detectors/misleading.py
+++ b/garak/detectors/misleading.py
@@ -57,6 +57,7 @@ class MustContradictNLI(HFDetector):
     DEFAULT_PARAMS = HFDetector.DEFAULT_PARAMS | {
         "detector_model_path": "ynie/roberta-large-snli_mnli_fever_anli_R1_R2_R3-nli",
         "detector_target_class": "label",
+        "tokenizer_kwargs": {"truncation": True, "max_length": 256},
     }
 
     bcp47 = "en"
@@ -65,17 +66,15 @@ class MustContradictNLI(HFDetector):
     def detect(self, attempt: Attempt) -> List[float]:
         import torch
 
-        max_length = 256
-
         premise = attempt.prompt
         results = []
         for hypothesis in attempt.all_outputs:
             tokenized_input_seq_pair = self.detector_tokenizer.encode_plus(
                 premise,
                 hypothesis,
-                max_length=max_length,
+                max_length=self.tokenizer_kwargs["max_length"],
                 return_token_type_ids=True,
-                truncation=True,
+                truncation=self.tokenizer_kwargs["truncation"],
             )
             input_ids = (
                 torch.Tensor(tokenized_input_seq_pair["input_ids"])

--- a/garak/detectors/misleading.py
+++ b/garak/detectors/misleading.py
@@ -27,10 +27,6 @@ class MustRefuteClaimModel(HFDetector):
     bcp47 = "en"
     accuracy = 0.9506  # 50:50 class balance in training data :/
 
-    def __init__(self, config_root=_config):
-        self.tokenizer_kwargs = {"padding": True, "truncation": True, "max_length": 512}
-        super().__init__(config_root=_config)
-
     def detect(self, attempt: Attempt) -> List[float]:
         results = super().detect(attempt)
         return [1 - i for i in results]  # we want refutations (label 1)
@@ -65,12 +61,6 @@ class MustContradictNLI(HFDetector):
 
     bcp47 = "en"
     active = False  # this one is slow, skip by default
-
-    def __init__(self, config_root=_config):
-        self.tokenizer_kwargs = {"padding": True, "truncation": True, "max_length": 512}
-        super().__init__(
-            config_root=config_root,
-        )
 
     def detect(self, attempt: Attempt) -> List[float]:
         import torch

--- a/garak/detectors/toxicity.py
+++ b/garak/detectors/toxicity.py
@@ -16,7 +16,3 @@ class ToxicCommentModel(HFDetector):
 
     bcp47 = "en"
     tags = ["avid-effect:ethics:E0301"]
-
-    def __init__(self, config_root=_config):
-        super().__init__(config_root=config_root)
-        self.tokenizer_kwargs = {"padding": True, "truncation": True, "max_length": 512}


### PR DESCRIPTION
Commonize parameters utilized in `HFDetector`, existing detectors currently use common arguments.

* promote `tokenizer_kwargs` as DEFAULT_PARAM of parent class
* remove `__init()__` overrides not longer needed

Expands on earlier exposure of model selection for HFDetectors in #810

These values seem independent from `hf_args` used to load the model.

Some additional code review suggests that `misleading.MustContradictNLI` does not actually consume these values since it overrides `detect()` with a custom method. Should this PR be expanded to consume values from `self.tokenizer_kwargs` for `max_length` and `truncation`?  The values are currently hardcoded in `detect()` as local values. It does not look like `padding` is ever consumed in `misleading.MustContradictNLI` and could be suppressed with instance defaults for that class.