### PR TITLE
fix output error when parallel_requests > 1 and supports_multiple_generations is False

### DIFF
--- a/garak/generators/base.py
+++ b/garak/generators/base.py
@@ -72,6 +72,18 @@ class Generator(Configurable):
     def _pre_generate_hook(self):
         pass
 
+    @staticmethod
+    def _verify_model_result(result: List[Union[str, None]]):
+        assert isinstance(
+            result, list
+        ), "_call_model must return a list"
+        assert (
+                len(result) == 1
+        ), "_call_model must return a list of one item when invoked as _call_model(prompt, 1)"
+        assert (
+            isinstance(result[0], str) or result[0] is None
+        ), "_call_model's item must be a string or None"
+
     def clear_history(self):
         pass
 
@@ -124,7 +136,7 @@ class Generator(Configurable):
                     for result in pool.imap_unordered(
                         self._call_model, [prompt] * generations_this_call
                     ):
-                        _verify_model_result(result)
+                        self._verify_model_result(result)
                         outputs.append(result[0])
                         multi_generator_bar.update(1)
 
@@ -139,15 +151,7 @@ class Generator(Configurable):
                     output_one = self._call_model(
                         prompt, 1
                     )  # generate once as `generation_iterator` consumes `generations_this_call`
-                    assert isinstance(
-                        output_one, list
-                    ), "_call_model must return a list"
-                    assert (
-                        len(output_one) == 1
-                    ), "_call_model must return a list of one item when invoked as _call_model(prompt, 1)"
-                    assert (
-                        isinstance(output_one[0], str) or output_one[0] is None
-                    ), "_call_model's item must be a string or None"
+                    self._verify_model_result(output_one)
                     outputs.append(output_one[0])
 
         return outputs

--- a/garak/generators/base.py
+++ b/garak/generators/base.py
@@ -124,7 +124,7 @@ class Generator(Configurable):
                     for result in pool.imap_unordered(
                         self._call_model, [prompt] * generations_this_call
                     ):
-                        outputs.append(result)
+                        outputs.append(result[0])
                         multi_generator_bar.update(1)
 
             else:

--- a/garak/generators/base.py
+++ b/garak/generators/base.py
@@ -124,6 +124,14 @@ class Generator(Configurable):
                     for result in pool.imap_unordered(
                         self._call_model, [prompt] * generations_this_call
                     ):
+                        if len(result) != 1:
+                            message = f"Expected a list of length 1 for generator with support_multiple_generations=False, got {len(result)}"
+                            logging.error(message)
+                            raise ValueError(message)
+                        if not isinstance(result[0], str):
+                            message = f"Expected string result got {type(result[0])}"
+                            logging.error(message)
+                            raise ValueError(message)
                         outputs.append(result[0])
                         multi_generator_bar.update(1)
 

--- a/garak/generators/base.py
+++ b/garak/generators/base.py
@@ -124,14 +124,7 @@ class Generator(Configurable):
                     for result in pool.imap_unordered(
                         self._call_model, [prompt] * generations_this_call
                     ):
-                        if len(result) != 1:
-                            message = f"Expected a list of length 1 for generator with support_multiple_generations=False, got {len(result)}"
-                            logging.error(message)
-                            raise ValueError(message)
-                        if not isinstance(result[0], str):
-                            message = f"Expected string result got {type(result[0])}"
-                            logging.error(message)
-                            raise ValueError(message)
+                        _verify_model_result(result)
                         outputs.append(result[0])
                         multi_generator_bar.update(1)
 

--- a/tests/generators/test_generators.py
+++ b/tests/generators/test_generators.py
@@ -7,6 +7,7 @@ import pytest
 import random
 
 from garak import _plugins
+from garak import _config
 from garak.generators.test import Blank, Repeat, Single
 from garak.generators.base import Generator
 
@@ -123,6 +124,17 @@ def test_generators_test_blank_many():
     assert (
         output[1] == ""
     ), "Blank generator .generate() output list should contain strings (second position)"
+
+
+def test_parallel_requests():
+    _config.system.parallel_requests = 2
+
+    g = _plugins.load_plugin("generators.test.Lipsum")
+    result = g.generate(prompt="this is a test", generations_this_call=3)
+    assert isinstance(result, list), "Generator generate() should return a list"
+    assert len(result) == 3, "Generator should return 3 results as requested"
+    assert all(isinstance(item, str) for item in result), "All items in the generate result should be strings"
+    assert all(len(item) > 0 for item in result), "All generated strings should be non-empty"
 
 
 @pytest.mark.parametrize("classname", GENERATORS)

--- a/tests/generators/test_nim.py
+++ b/tests/generators/test_nim.py
@@ -6,6 +6,7 @@ import pytest
 
 import garak.cli
 from garak.generators.nim import NVOpenAIChat
+from garak import _config
 
 
 @pytest.mark.skipif(
@@ -43,6 +44,20 @@ def test_nim_parallel_attempts():
         "-m nim -p lmrc.Anthropomorphisation -g 1 -n google/gemma-2b --parallel_attempts 10".split()
     )
     assert True
+
+
+@pytest.mark.skipif(
+    os.getenv(NVOpenAIChat.ENV_VAR, None) is None,
+    reason=f"NIM API key is not set in {NVOpenAIChat.ENV_VAR}",
+)
+def test_nim_parallel_requests():
+    _config.system.parallel_requests = 2
+
+    g = NVOpenAIChat(name="nvidia/nemotron-4-340b-instruct")
+
+    result = g.generate("this is a test", generations_this_call=3)
+    assert isinstance(result, list), "NIM generate() should return a list"
+    assert isinstance(result[0], str), "Items in the generate result should be strings"
 
 
 @pytest.mark.skipif(

--- a/tests/generators/test_nim.py
+++ b/tests/generators/test_nim.py
@@ -6,7 +6,6 @@ import pytest
 
 import garak.cli
 from garak.generators.nim import NVOpenAIChat
-from garak import _config
 
 
 @pytest.mark.skipif(

--- a/tests/generators/test_nim.py
+++ b/tests/generators/test_nim.py
@@ -50,20 +50,6 @@ def test_nim_parallel_attempts():
     os.getenv(NVOpenAIChat.ENV_VAR, None) is None,
     reason=f"NIM API key is not set in {NVOpenAIChat.ENV_VAR}",
 )
-def test_nim_parallel_requests():
-    _config.system.parallel_requests = 2
-
-    g = NVOpenAIChat(name="nvidia/nemotron-4-340b-instruct")
-
-    result = g.generate("this is a test", generations_this_call=3)
-    assert isinstance(result, list), "NIM generate() should return a list"
-    assert isinstance(result[0], str), "Items in the generate result should be strings"
-
-
-@pytest.mark.skipif(
-    os.getenv(NVOpenAIChat.ENV_VAR, None) is None,
-    reason=f"NIM API key is not set in {NVOpenAIChat.ENV_VAR}",
-)
 def test_nim_hf_detector():
     garak.cli.main("-m nim -p lmrc.Bullying -g 1 -n google/gemma-2b".split())
     assert True


### PR DESCRIPTION
Resolve: https://github.com/leondz/garak/pull/861#issuecomment-2317514542
- FIX Probes fail with nim generator when `parallel_requests` > 1
- Error: `TypeError: expected string or bytes-like object, got 'list'`
- When a generator's  'supports_multiple_generations' is false 
- And the 'parallel_requests' > 1,
- Ensure the generator output is added as a string, not a list.