### PR TITLE
validate detector doc_uri

### DIFF
--- a/garak/detectors/base.py
+++ b/garak/detectors/base.py
@@ -19,7 +19,7 @@ import garak.attempt
 class Detector(Configurable):
     """Base class for objects that define a way of detecting a probe hit / LLM failure"""
 
-    doc_uri = ""  # reference
+    doc_uri = None  # reference
     bcp47 = None  # language this is for. format: a comma-separated list of bcp47 tags, or "*"
     precision = 0.0
     recall = 0.0

--- a/tests/detectors/test_detectors.py
+++ b/tests/detectors/test_detectors.py
@@ -131,10 +131,9 @@ def test_detector_metadata(classname):
         assert bcp47_part == "*" or re.match(
             BCP_LENIENT_RE, bcp47_part
         ), "langs must be described with either * or a bcp47 code"
-    assert isinstance(
-        d.doc_uri, str
-    ), "detectors should give a doc uri describing/citing the attack"
-    if len(d.doc_uri) > 1:
+    assert isinstance(d.doc_uri, str) or d.doc_uri is None
+    if isinstance(d.doc_uri, str):
+        assert len(d.doc_uri) > 1, "string doc_uris must be populated. else use None"
         assert d.doc_uri.lower().startswith(
             "http"
         ), "doc uris should be fully-specified absolute HTTP addresses"


### PR DESCRIPTION
Many detectors are roll-our-own, so None is valid. If it's a string, it should be an absolute http address