### PR TITLE
revise default generations value to 5

### DIFF
--- a/garak/resources/garak.core.yaml
+++ b/garak/resources/garak.core.yaml
@@ -10,7 +10,7 @@ run:
   seed:
   deprefix: true
   eval_threshold: 0.5
-  generations: 10
+  generations: 5
   probe_tags:
 
 plugins:


### PR DESCRIPTION
* original figure was a guess
* don't have evidence that 10 is markedly better than 5
* do have evidence that people find garak slow
* statistical strength of results is predicated on both generations and prompt count - not just generations
* let's halve our running time and I guess even halve our default CO2 emissions while we're at it

* aside - we should def. highlight "insufficient inference", i.e. `prompts*generations < threshold`, in reporting - once prompt counting feature is done