### PR TITLE
Migrate away from Conda to Venv

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,13 +58,13 @@ python -m pip install -U git+https://github.com/leondz/garak.git@main
 
 ### Clone from source
 
-`garak` has its own dependencies. You can to install `garak` in its own Conda environment:
+`garak` has its own dependencies. You can to install `garak` in its own Venv environment:
 
 ```
-conda create --name garak "python>=3.10,<=3.12"
-conda activate garak
 gh repo clone leondz/garak
 cd garak
+python3 -m venv garak_env
+source garak_env/bin/activate # On Windows, use garak_env\Scripts\activate
 python -m pip install -e .
 ```
 

--- a/README.md
+++ b/README.md
@@ -61,10 +61,10 @@ python -m pip install -U git+https://github.com/leondz/garak.git@main
 `garak` has its own dependencies. You can to install `garak` in its own Venv environment:
 
 ```
-gh repo clone leondz/garak
-cd garak
 python3 -m venv garak_env
 source garak_env/bin/activate # On Windows, use garak_env\Scripts\activate
+gh repo clone leondz/garak
+cd garak
 python -m pip install -e .
 ```
 

--- a/docs/source/contributing.generator.rst
+++ b/docs/source/contributing.generator.rst
@@ -234,7 +234,7 @@ A good first step is to fire up the Python interpreter and try to import the mod
 
 .. code-block:: bash
 
-    $ conda activate garak
+    $ source garak_env/bin/activate
     $ python
     $ python
     Python 3.11.9 (main, Apr 19 2024, 16:48:06) [GCC 11.2.0] on linux

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -35,12 +35,12 @@ For development: clone from `git`
 
 You can also clone the source and run `garak` directly. This works fine and is recommended for development.
 
-`garak` has its own dependencies. You can to install `garak` in its own Conda environment:
+`garak` has its own dependencies. You can to install `garak` in its own Venv environment:
 
 .. code-block:: console
 
-    conda create --name garak "python>=3.10,<=3.12"
-    conda activate garak
+    python3 -m venv garak_env
+    source garak_env/bin/activate # On Windows, use garak_env\Scripts\activate
     gh repo clone leondz/garak
     cd garak
     python3 -m pip install -r requirements.txt


### PR DESCRIPTION
Resolve https://github.com/leondz/garak/issues/844
- Use Venv instead of Conda
- A bit of research indicates Venv can do everything we need:
    -  https://stackoverflow.com/questions/67065725/conda-env-vs-venv-pyenv-virtualenv-etc
- Alternatives: 
    - https://github.com/mamba-org/mamba
    - https://github.com/astral-sh/uv
    - https://www.reddit.com/r/learnpython/comments/1aexqyy/alternatives_to_anaconda/