### PR TITLE
Ollama generator

### DIFF
--- a/garak/generators/ollama.py
+++ b/garak/generators/ollama.py
@@ -1,0 +1,83 @@
+"""Ollama interface"""
+
+from typing import List, Union
+
+import backoff
+import ollama
+
+from garak import _config
+from garak.generators.base import Generator
+
+
+def _give_up(error):
+    return isinstance(error, ollama.ResponseError) and error.status_code == 404
+
+
+class OllamaGenerator(Generator):
+    """Interface for Ollama endpoints
+
+    Model names can be passed in short form like "llama2" or specific versions or sizes like "gemma:7b" or "llama2:latest"
+    """
+
+    DEFAULT_PARAMS = Generator.DEFAULT_PARAMS | {
+        "timeout": 30,  # Add a timeout of 30 seconds. Ollama can tend to hang forever on failures, if this is not present
+        "host": "127.0.0.1:11434",  # The default host of an Ollama server. This should maybe be loaded from a config file somewhere
+    }
+
+    active = True
+    generator_family_name = "Ollama"
+
+    def __init__(self, name="", config_root=_config):
+        super().__init__(name, config_root)  # Sets the name and generations
+
+        self.client = ollama.Client(
+            self.DEFAULT_PARAMS["host"], timeout=self.DEFAULT_PARAMS["timeout"]
+        )  # Instantiates the client with the timeout
+
+    @backoff.on_exception(
+        backoff.fibo,
+        (TimeoutError, ollama.ResponseError),
+        max_value=70,
+        giveup=_give_up,
+    )
+    @backoff.on_predicate(
+        backoff.fibo, lambda ans: ans == None or len(ans) == 0, max_tries=3
+    )  # Ollama sometimes returns empty responses. Only 3 retries to not delay generations expecting empty responses too much
+    def _call_model(
+        self, prompt: str, generations_this_call: int = 1
+    ) -> List[Union[str, None]]:
+        response = self.client.generate(self.name, prompt)
+        return [response["response"]]
+
+
+class OllamaGeneratorChat(OllamaGenerator):
+    """Interface for Ollama endpoints, using the chat functionality
+
+    Model names can be passed in short form like "llama2" or specific versions or sizes like "gemma:7b" or "llama2:latest"
+    """
+
+    @backoff.on_exception(
+        backoff.fibo,
+        (TimeoutError, ollama.ResponseError),
+        max_value=70,
+        giveup=_give_up,
+    )
+    @backoff.on_predicate(
+        backoff.fibo, lambda ans: ans == None or len(ans) == 0, max_tries=3
+    )  # Ollama sometimes returns empty responses. Only 3 retries to not delay generations expecting empty responses too much
+    def _call_model(
+        self, prompt: str, generations_this_call: int = 1
+    ) -> List[Union[str, None]]:
+        response = self.client.chat(
+            model=self.name,
+            messages=[
+                {
+                    "role": "user",
+                    "content": prompt,
+                },
+            ],
+        )
+        return [response["message"]["content"]]
+
+
+DEFAULT_CLASS = "OllamaGeneratorChat"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ dependencies = [
   "lorem==0.1.1",
   "xdg-base-dirs>=6.0.1",
   "wn==0.9.5",
+  "ollama>=0.1.7"
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,6 +34,7 @@ python-magic>=0.4.21; sys_platform != "win32"
 lorem==0.1.1
 xdg-base-dirs>=6.0.1
 wn==0.9.5
+ollama>=0.1.7
 # tests
 pytest>=8.0
 requests-mock==1.12.1

--- a/tests/generators/test_ollama.py
+++ b/tests/generators/test_ollama.py
@@ -1,0 +1,86 @@
+import pytest
+import ollama
+from httpx import ConnectError
+from garak.generators.ollama import OllamaGeneratorChat, OllamaGenerator
+
+PINGED_OLLAMA_SERVER = (
+    False  # Avoid calling the server multiple times if it is not running
+)
+OLLAMA_SERVER_UP = False
+
+
+def ollama_is_running():
+    global PINGED_OLLAMA_SERVER
+    global OLLAMA_SERVER_UP
+
+    if not PINGED_OLLAMA_SERVER:
+        try:
+            ollama.list()  # Gets a list of all pulled models. Used as a ping
+            OLLAMA_SERVER_UP = True
+        except ConnectError:
+            OLLAMA_SERVER_UP = False
+        finally:
+            PINGED_OLLAMA_SERVER = True
+    return OLLAMA_SERVER_UP
+
+
+def no_models():
+    return len(ollama.list()) == 0 or len(ollama.list()["models"]) == 0
+
+
+@pytest.mark.skipif(
+    not ollama_is_running(),
+    reason=f"Ollama server is not currently running",
+)
+def test_error_on_nonexistant_model_chat():
+    model_name = "non-existant-model"
+    gen = OllamaGeneratorChat(model_name)
+    with pytest.raises(ollama.ResponseError):
+        gen.generate("This shouldnt work")
+
+
+@pytest.mark.skipif(
+    not ollama_is_running(),
+    reason=f"Ollama server is not currently running",
+)
+def test_error_on_nonexistant_model():
+    model_name = "non-existant-model"
+    gen = OllamaGenerator(model_name)
+    with pytest.raises(ollama.ResponseError):
+        gen.generate("This shouldnt work")
+
+
+@pytest.mark.skipif(
+    not ollama_is_running(),
+    reason=f"Ollama server is not currently running",
+)
+@pytest.mark.skipif(
+    not ollama_is_running() or no_models(),  # Avoid checking models if no server
+    reason=f"No Ollama models pulled",
+)
+# This test might fail if the GPU is busy, and the generation takes more than 30 seconds
+def test_generation_on_pulled_model_chat():
+    model_name = ollama.list()["models"][0]["name"]
+    gen = OllamaGeneratorChat(model_name)
+    responses = gen.generate('Say "Hello!"')
+    assert len(responses) == 1
+    assert all(isinstance(response, str) for response in responses)
+    assert all(len(response) > 0 for response in responses)
+
+
+@pytest.mark.skipif(
+    not ollama_is_running(),
+    reason=f"Ollama server is not currently running",
+)
+@pytest.mark.skipif(
+    not ollama_is_running() or no_models(),  # Avoid checking models if no server
+    reason=f"No Ollama models pulled",
+)
+# This test might fail if the GPU is busy, and the generation takes more than 30 seconds
+def test_generation_on_pulled_model():
+    model_name = ollama.list()["models"][0]["name"]
+    gen = OllamaGenerator(model_name)
+    responses = gen.generate('Say "Hello!"')
+    assert len(responses) == 1
+    assert all(isinstance(response, str) for response in responses)
+    assert all(len(response) > 0 for response in responses)


### PR DESCRIPTION
Add two Ollama generators, using either the chat or generate functions from the Ollama package.
Add tests, that are skipped when no Ollama server is running.