### PR TITLE
paraphrase fast consistent model device

### DIFF
--- a/garak/buffs/paraphrase.py
+++ b/garak/buffs/paraphrase.py
@@ -74,13 +74,13 @@ class Fast(Buff, HFCompatible):
     """CPU-friendly paraphrase buff based on Humarin's T5 paraphraser"""
 
     DEFAULT_PARAMS = Buff.DEFAULT_PARAMS | {
-        "hf_args": {"device": "cpu", "torch_dtype": "float32"}
+        "para_model_name": "garak-llm/chatgpt_paraphraser_on_T5_base",
+        "hf_args": {"device": "cpu", "torch_dtype": "float32"},
     }
     bcp47 = "en"
     doc_uri = "https://huggingface.co/humarin/chatgpt_paraphraser_on_T5_base"
 
     def __init__(self, config_root=_config) -> None:
-        self.para_model_name = "garak-llm/chatgpt_paraphraser_on_T5_base"
         self.num_beams = 5
         self.num_beam_groups = 5
         self.num_return_sequences = 5


### PR DESCRIPTION
When running tests on a platform with a `cuda` capable device, errors can be reported due to how the model is instantiated.

```
>       return torch.embedding(weight, input, padding_idx, scale_grad_by_freq, sparse)
E       RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu! (when checking argument for argument index in method wrapper_CUDA__index_select)

../../../miniconda3/envs/garak/lib/python3.12/site-packages/torch/nn/functional.py:2267: RuntimeError
---------------------------------------- Captured stdout call -----------------------------------------
🦾 loading buff: paraphrase.Fast
======================================= short test summary info =======================================
FAILED tests/buffs/test_buffs.py::test_buff_load_and_transform[buffs.paraphrase.Fast] - RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:...
======================== 1 failed, 1771 passed, 32 skipped in 90.16s (0:01:30) ========================
```

Recent changes to support a configuration of plugins and huggingface models as used in this class lead to further identification of possible exceptions when processing a `HFCompatible` class that does not have `hf_args` or when providing options for huggingface model constructors that favor the newer `device_map` argument to `device`.

This PR also offers more visibility into a the coupling that exists between various plugin types that consume the `generator` plugin type. While not addressed in this PR, a future iteration should review module structure to determine if there are ways to limit or guide coupling of different plugin types. So far only `generator` types plugins are consumed by other plugin types primarily for local huggingface model utilization.
