### PR TITLE
Force cache build in automation

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,10 @@
 import pytest
 import os
-from garak import _config
+from garak import _config, _plugins
+
+# force a local cache file to exist when this top level import is loaded
+if not os.path.isfile(_plugins.PluginCache._user_plugin_cache_filename):
+    _plugins.PluginCache.instance()
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
If no existing cache is found for a test run as would be the case for test automation, request a cache instance. This will cause the cache to build once if any test is run by `pytest`.