### PR TITLE
tweak: defer import of slow Llava* classes

### DIFF
--- a/garak/generators/huggingface.py
+++ b/garak/generators/huggingface.py
@@ -24,7 +24,6 @@ import warnings
 import backoff
 import torch
 from PIL import Image
-from transformers import LlavaNextProcessor, LlavaNextForConditionalGeneration
 
 from garak import _config
 from garak.exception import ModelNameMissingError, GarakException
@@ -656,6 +655,8 @@ class LLaVA(Generator, HFCompatible):
             raise ModelNameMissingError(
                 f"Invalid model name {self.name}, current support: {self.supported_models}."
             )
+
+        from transformers import LlavaNextProcessor, LlavaNextForConditionalGeneration
 
         self.device = self._select_hf_device()
         model_kwargs = self._gather_hf_params(


### PR DESCRIPTION
i don't want to spend any more of my life waiting for these to load during dev

longer-term things to address:
* don't speculatively load torch or Image either
* move `HFCompatible` out ~~~_to the ether_~~~ so that `generators.base` no longer has `from garak.generators.huggingface import HFCompatible`