### PR TITLE
cli: `--parallel_attempts` hint

### DIFF
--- a/garak/cli.py
+++ b/garak/cli.py
@@ -270,8 +270,7 @@ def main(arguments=None) -> None:
 
     # load site config before loading CLI config
     _cli_config_supplied = args.config is not None
-    if _cli_config_supplied:
-        _config.load_config(run_config_filename=args.config)
+    _config.load_config(run_config_filename=args.config)
 
     # extract what was actually passed on CLI; use a masking argparser
     aux_parser = argparse.ArgumentParser(argument_default=argparse.SUPPRESS)

--- a/garak/cli.py
+++ b/garak/cli.py
@@ -489,6 +489,11 @@ def main(arguments=None) -> None:
                 f"generators.{_config.plugins.model_type}", config_root=_config
             )
 
+            if generator.parallel_capable and not _config.system.parallel_attempts:
+                print(
+                    f"⚠️  This run can be sped up. Generator '{generator.fullname}' supports parallelism! 🥳 Consider using `--parallel_requests 16` (or higher) to accelerate your run. 🐌"
+                )
+
             if "generate_autodan" in args and args.generate_autodan:
                 from garak.resources.autodan import autodan_generate
 

--- a/garak/cli.py
+++ b/garak/cli.py
@@ -491,7 +491,7 @@ def main(arguments=None) -> None:
 
             if generator.parallel_capable and not _config.system.parallel_attempts:
                 print(
-                    f"⚠️  This run can be sped up. Generator '{generator.fullname}' supports parallelism! 🥳 Consider using `--parallel_requests 16` (or higher) to accelerate your run. 🐌"
+                    f"⚠️  This run can be sped up. Generator '{generator.fullname}' supports parallelism! 🥳 Consider using `--parallel_requests 16` (or more) to greatly accelerate your run. 🐌"
                 )
 
             if "generate_autodan" in args and args.generate_autodan:

--- a/garak/cli.py
+++ b/garak/cli.py
@@ -254,7 +254,9 @@ def main(arguments=None) -> None:
     logging.debug("args - full argparse: %s", args)
 
     # load site config before loading CLI config
-    _config.load_config(run_config_filename=args.config)
+    _cli_config_supplied = args.config is not None
+    if _cli_config_supplied:
+        _config.load_config(run_config_filename=args.config)
 
     # extract what was actually passed on CLI; use a masking argparser
     aux_parser = argparse.ArgumentParser(argument_default=argparse.SUPPRESS)
@@ -489,9 +491,13 @@ def main(arguments=None) -> None:
                 f"generators.{_config.plugins.model_type}", config_root=_config
             )
 
-            if generator.parallel_capable and not _config.system.parallel_attempts:
+            if (
+                not _cli_config_supplied
+                and generator.parallel_capable
+                and _config.system.parallel_attempts is False
+            ):
                 print(
-                    f"⚠️  This run can be sped up. Generator '{generator.fullname}' supports parallelism! 🥳 Consider using `--parallel_requests 16` (or more) to greatly accelerate your run. 🐌"
+                    f"⚠️  This run can be sped up 🥳 Generator '{generator.fullname}' supports parallelism! Consider using `--parallel_requests 16` (or more) to greatly accelerate your run. 🐌"
                 )
 
             if "generate_autodan" in args and args.generate_autodan:

--- a/garak/cli.py
+++ b/garak/cli.py
@@ -3,7 +3,22 @@
 
 """Flow for invoking garak from the command line"""
 
+import random
+
+HINT_CHANCE = 0.25
+
 command_options = "list_detectors list_probes list_generators list_buffs list_config plugin_info interactive report version".split()
+
+
+def hint(msg, logging=None):
+    # sub-optimal, but because our logging setup is thin & uses the global
+    # default, placing a top-level import can break logging - so we can't
+    # assume `logging` is imported at this point.
+    msg = f"⚠️  {msg}"
+    if logging is not None:
+        logging.info(msg)
+    if random.random() < HINT_CHANCE:
+        print(msg)
 
 
 def main(arguments=None) -> None:
@@ -496,8 +511,9 @@ def main(arguments=None) -> None:
                 and generator.parallel_capable
                 and _config.system.parallel_attempts is False
             ):
-                print(
-                    f"⚠️  This run can be sped up 🥳 Generator '{generator.fullname}' supports parallelism! Consider using `--parallel_requests 16` (or more) to greatly accelerate your run. 🐌"
+                hint(
+                    f"This run can be sped up 🥳 Generator '{generator.fullname}' supports parallelism! Consider using `--parallel_requests 16` (or more) to greatly accelerate your run. 🐌",
+                    logging=logging,
                 )
 
             if "generate_autodan" in args and args.generate_autodan:

--- a/garak/cli.py
+++ b/garak/cli.py
@@ -3,9 +3,6 @@
 
 """Flow for invoking garak from the command line"""
 
-
-HINT_CHANCE = 0.25
-
 command_options = "list_detectors list_probes list_generators list_buffs list_config plugin_info interactive report version".split()
 
 
@@ -498,7 +495,7 @@ def main(arguments=None) -> None:
                 and generator.parallel_capable
                 and _config.system.parallel_attempts is False
             ):
-                hint(
+                command.hint(
                     f"This run can be sped up 🥳 Generator '{generator.fullname}' supports parallelism! Consider using `--parallel_requests 16` (or more) to greatly accelerate your run. 🐌",
                     logging=logging,
                 )

--- a/garak/cli.py
+++ b/garak/cli.py
@@ -3,22 +3,10 @@
 
 """Flow for invoking garak from the command line"""
 
-import random
 
 HINT_CHANCE = 0.25
 
 command_options = "list_detectors list_probes list_generators list_buffs list_config plugin_info interactive report version".split()
-
-
-def hint(msg, logging=None):
-    # sub-optimal, but because our logging setup is thin & uses the global
-    # default, placing a top-level import can break logging - so we can't
-    # assume `logging` is imported at this point.
-    msg = f"⚠️  {msg}"
-    if logging is not None:
-        logging.info(msg)
-    if random.random() < HINT_CHANCE:
-        print(msg)
 
 
 def main(arguments=None) -> None:

--- a/garak/command.py
+++ b/garak/command.py
@@ -5,8 +5,18 @@
 
 import logging
 import json
+import random
 
-import garak.cli
+
+def hint(msg, logging=None):
+    # sub-optimal, but because our logging setup is thin & uses the global
+    # default, placing a top-level import can break logging - so we can't
+    # assume `logging` is imported at this point.
+    msg = f"⚠️  {msg}"
+    if logging is not None:
+        logging.info(msg)
+    if random.random() < HINT_CHANCE:
+        print(msg)
 
 
 def start_logging():
@@ -45,7 +55,7 @@ def start_run():
     logging.info("run started at %s", _config.transient.starttime_iso)
     # print("ASSIGN UUID", args)
     if _config.system.lite and "probes" not in _config.transient.cli_args and not _config.transient.cli_args.list_probes and not _config.transient.cli_args.list_detectors and not _config.transient.cli_args.list_generators and not _config.transient.cli_args.list_buffs and not _config.transient.cli_args.list_config and not _config.transient.cli_args.plugin_info and not _config.run.interactive:  # type: ignore
-        garak.cli.hint(
+        hint(
             "The current/default config is optimised for speed rather than thoroughness. Try e.g. --config full for a stronger test, or specify some probes.",
             logging=logging,
         )

--- a/garak/command.py
+++ b/garak/command.py
@@ -6,6 +6,8 @@
 import logging
 import json
 
+import garak.cli
+
 
 def start_logging():
     from garak import _config
@@ -40,11 +42,12 @@ def start_run():
     from pathlib import Path
     from garak import _config
 
-    logging.info("started at %s", _config.transient.starttime_iso)
+    logging.info("run started at %s", _config.transient.starttime_iso)
     # print("ASSIGN UUID", args)
     if _config.system.lite and "probes" not in _config.transient.cli_args and not _config.transient.cli_args.list_probes and not _config.transient.cli_args.list_detectors and not _config.transient.cli_args.list_generators and not _config.transient.cli_args.list_buffs and not _config.transient.cli_args.list_config and not _config.transient.cli_args.plugin_info and not _config.run.interactive:  # type: ignore
-        print(
-            "⚠️  The current/default config is optimised for speed rather than thoroughness. Try e.g. --config full for a stronger test, or specify some probes."
+        garak.cli.hint(
+            "The current/default config is optimised for speed rather than thoroughness. Try e.g. --config full for a stronger test, or specify some probes.",
+            logging=logging,
         )
     _config.transient.run_id = str(uuid.uuid4())  # uuid1 is safe but leaks host info
     report_path = Path(_config.reporting.report_dir)

--- a/garak/command.py
+++ b/garak/command.py
@@ -44,7 +44,7 @@ def start_run():
     # print("ASSIGN UUID", args)
     if _config.system.lite and "probes" not in _config.transient.cli_args and not _config.transient.cli_args.list_probes and not _config.transient.cli_args.list_detectors and not _config.transient.cli_args.list_generators and not _config.transient.cli_args.list_buffs and not _config.transient.cli_args.list_config and not _config.transient.cli_args.plugin_info and not _config.run.interactive:  # type: ignore
         print(
-            "⚠️ The current/default config is optimised for speed rather than thoroughness. Try e.g. --config full for a stronger test, or specify some probes."
+            "⚠️  The current/default config is optimised for speed rather than thoroughness. Try e.g. --config full for a stronger test, or specify some probes."
         )
     _config.transient.run_id = str(uuid.uuid4())  # uuid1 is safe but leaks host info
     report_path = Path(_config.reporting.report_dir)

--- a/garak/command.py
+++ b/garak/command.py
@@ -7,6 +7,8 @@ import logging
 import json
 import random
 
+HINT_CHANCE = 0.25
+
 
 def hint(msg, logging=None):
     # sub-optimal, but because our logging setup is thin & uses the global

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -266,7 +266,9 @@ def test_yaml_param_settings(param):
         )  # add list_config as the action so we don't actually run
         subconfig = getattr(_config, param_locs[option])
         os.remove(tmp.name)
-        assert getattr(subconfig, option) == value
+        assert (
+            getattr(subconfig, option) == value
+        ), f"CLI-supplied config values for {option} should override core config"
 
 
 # # test that site YAML overrides core YAML # needs file staging for site yaml
@@ -281,7 +283,9 @@ def test_site_yaml_overrides_core_yaml():
         f.flush()
         garak.cli.main(["--list_config"])
 
-    assert _config.run.eval_threshold == 0.777
+    assert (
+        _config.run.eval_threshold == 0.777
+    ), "Site config should override core config if loaded correctly"
 
 
 # # test that run YAML overrides site YAML # needs file staging for site yaml
@@ -301,7 +305,9 @@ def test_run_yaml_overrides_site_yaml():
         f.flush()
         garak.cli.main(["--list_config", "--eval_threshold", str(0.9001)])
 
-    assert _config.run.eval_threshold == 0.9001
+    assert (
+        _config.run.eval_threshold == 0.9001
+    ), "CLI-specified config values should override site config"
 
 
 # test that CLI config overrides run YAML
@@ -322,7 +328,9 @@ def test_cli_overrides_run_yaml():
             ["--config", tmp.name, "-s", f"{override_seed}", "--list_config"]
         )  # add list_config as the action so we don't actually run
         os.remove(tmp.name)
-        assert _config.run.seed == override_seed
+        assert (
+            _config.run.seed == override_seed
+        ), "CLI-specificd config values should override values in config file names on CLI"
 
 
 # test probe_options YAML


### PR DESCRIPTION
Resolves #928

Inform CLI users that garak isn't running as efficiently as it can, if they're not using `parallel_attempts` but their generator can take it

## Verification

Invoke garak in a way that can benefit from parallelisation. A hint should appear. e.g.

`python -m garak -m test.Lipsum`


```
(garak) 15:08:27 x1:~/dev/garak [cli/parallel_hint] $ python -m garak -m test.Lipsum
garak LLM vulnerability scanner v0.9.0.16.post1 ( https://github.com/leondz/garak ) at 2024-09-24T15:08:43.577976
📜 logging to /home/lderczynski/.local/share/garak/garak.log
🦜 loading generator: Test: Lorem Ipsum
⚠️  This run can be sped up. Generator 'Test:Lorem Ipsum' supports parallelism! 🥳 Consider using `--parallel_requests 16` (or higher) to accelerate your run. 🐌
⚠️  The current/default config is optimised for speed rather than thoroughness. Try e.g. --config full for a stronger test, or specify some probes.
📜 reporting to /home/lderczynski/.local/share/garak/garak_runs/garak.fd912c89-403a-4cab-a781-b8224554602d.report.jsonl
^CUser cancel received, terminating all runs
```