### PR TITLE
add code coverage options

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,3 +116,7 @@ filterwarnings = [
     "ignore",
     "default:::garak",
 ]
+
+[tool.coverage.run]
+source = ["./garak"]
+omit = ["tests/*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,7 @@ tests = [
   "pytest>=8.0",
   "requests-mock==1.12.1",
   "respx>=0.21.1",
+  "pytest-cov>=5.0.0"
 ]
 lint = [
   "black==24.4.2",

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,6 +38,7 @@ wn==0.9.5
 pytest>=8.0
 requests-mock==1.12.1
 respx>=0.21.1
+pytest-cov>=5.0.0
 # lint
 black==24.4.2
 pylint>=3.1.0


### PR DESCRIPTION
Enables usage of the `pytest-cov` plugin to limit coverage number to project source code in the `garak/` path.

Quality of life entry for exploring test coverage values. Restricting the output to library code without including the `tests/` path [requires configuration be place in a settings file](https://github.com/pytest-dev/pytest-cov/issues/373#issuecomment-566046153) so `pyproject.toml` is elected as already available in this project.

Output of coverage is similar to:
```
---------- coverage: platform darwin, python 3.12.4-final-0 ----------
Name                                            Stmts   Miss  Cover
-------------------------------------------------------------------
garak/__init__.py                                   3      0   100%
garak/__main__.py                                   7      7     0%
garak/_config.py                                  141     12    91%
garak/_plugins.py                                 238     32    87%
...
garak/resources/theme/__init__.py                   3      0   100%
-------------------------------------------------------------------
TOTAL                                            7744   3029    61%
```

## Verification

- [x] Run with the following:
```
python -m pip install pytest-cov
python -m pytest tests --cov
```

