### PR TITLE
reporting: tidy config details, add payload audit info

### DIFF
--- a/garak/analyze/report_digest.py
+++ b/garak/analyze/report_digest.py
@@ -80,7 +80,7 @@ def compile_digest(report_path, taxonomy=_config.reporting.taxonomy):
             elif record["entry_type"] == "payload_init":
                 payloads.append(
                     record["payload_name"]
-                    + " "
+                    + "  "
                     + pprint.pformat(record, sort_dicts=True, width=60)
                 )
 

--- a/garak/analyze/report_digest.py
+++ b/garak/analyze/report_digest.py
@@ -7,6 +7,7 @@ import importlib
 import json
 import markdown
 import os
+import pprint
 import re
 import sys
 
@@ -63,6 +64,7 @@ def plugin_docstring_to_description(docstring):
 
 def compile_digest(report_path, taxonomy=_config.reporting.taxonomy):
     evals = []
+    payloads = []
     setup = defaultdict(str)
     with open(report_path, "r", encoding="utf-8") as reportfile:
         for line in reportfile:
@@ -75,6 +77,12 @@ def compile_digest(report_path, taxonomy=_config.reporting.taxonomy):
                 run_uuid = record["run"]
             elif record["entry_type"] == "start_run setup":
                 setup = record
+            elif record["entry_type"] == "payload_init":
+                payloads.append(
+                    record["payload_name"]
+                    + " "
+                    + pprint.pformat(record, sort_dicts=True, width=60)
+                )
 
     calibration = garak.analyze.calibration.Calibration()
     calibration_used = False
@@ -85,10 +93,11 @@ def compile_digest(report_path, taxonomy=_config.reporting.taxonomy):
             "garak_version": garak_version,
             "start_time": start_time,
             "run_uuid": run_uuid,
-            "setup": repr(setup),
+            "setup": pprint.pformat(setup, sort_dicts=True, width=60),
             "probespec": setup["plugins.probe_spec"],
             "model_type": setup["plugins.model_type"],
             "model_name": setup["plugins.model_name"],
+            "payloads": payloads,
         }
     )
 

--- a/garak/analyze/templates/digest_header.jinja
+++ b/garak/analyze/templates/digest_header.jinja
@@ -71,13 +71,25 @@ h2,h3,h4 {padding-top: 10px; padding-bottom: 10px}
 <h1>garak run: {{reportfile}}</h1>
 <button class="accordion">⚙️ view config</button>
 <div style="border:solid black 1px; padding: 5px; margin: 5px" class="panel">
-<h2>config</h2>
-<p>filename: {{reportfile}}</p>
-<p>garak version: {{garak_version}}</p>
-<p>generator: {{model_type}}.{{model_name}}</p>
-<p>started at: {{start_time}}</p>
-<p>run config: {{setup}}</p>
-<p>probe spec: {{probespec}}</p>
+<h2>config details</h2>
+<pre>
+filename: {{reportfile}}
+
+garak version: {{garak_version}}
+
+generator: {{model_type}}.{{model_name}}
+
+probe spec: {{probespec}}
+
+run started at: {{start_time}}
+
+run config: {{setup}}
+
+{% for payload in payloads %}
+payload: {{payload}}
+
+{% endfor %}
+</pre>
 </div>
 
 {%if model_name %}


### PR DESCRIPTION
consumes `payload_info` entries in the report

## Verification

- run a probe that uses a payload, e.g. `LatentInjectionTranslationEnFr`
- open the html report
- check that there is an entry in the "config details" expandable section of the page that details the relevant payload's metadata


See also https://github.com/leondz/garak/pull/930#pullrequestreview-2322752043