### PR TITLE
architecture: factor HFCompatible out

### DIFF
--- a/garak/buffs/paraphrase.py
+++ b/garak/buffs/paraphrase.py
@@ -14,11 +14,14 @@ from garak.resources.api.huggingface import HFCompatible
 class PegasusT5(Buff):
     """Paraphrasing buff using Pegasus model"""
 
+    DEFAULT_PARAMS = Buff.DEFAULT_PARAMS | {
+        "para_model_name": "garak-llm/pegasus_paraphrase",
+        "hf_args": {"device": "cpu", "torch_dtype": "float32"},
+    }
     bcp47 = "en"
     doc_uri = "https://huggingface.co/tuner007/pegasus_paraphrase"
 
     def __init__(self, config_root=_config) -> None:
-        self.para_model_name = "garak-llm/pegasus_paraphrase"  # https://huggingface.co/tuner007/pegasus_paraphrase
         self.max_length = 60
         self.temperature = 1.5
         self.num_return_sequences = 6

--- a/garak/buffs/paraphrase.py
+++ b/garak/buffs/paraphrase.py
@@ -7,8 +7,8 @@ from collections.abc import Iterable
 
 import garak.attempt
 from garak import _config
-from garak.generators.huggingface import HFCompatible
 from garak.buffs.base import Buff
+from garak.resources.api.huggingface import HFCompatible
 
 
 class PegasusT5(Buff):

--- a/garak/buffs/paraphrase.py
+++ b/garak/buffs/paraphrase.py
@@ -16,7 +16,9 @@ class PegasusT5(Buff, HFCompatible):
 
     DEFAULT_PARAMS = Buff.DEFAULT_PARAMS | {
         "para_model_name": "garak-llm/pegasus_paraphrase",
-        "hf_args": {"device": "cpu"}, # torch_dtype doesn't have standard support in Pegasus
+        "hf_args": {
+            "device": "cpu"
+        },  # torch_dtype doesn't have standard support in Pegasus
         "max_length": 60,
         "temperature": 1.5,
     }
@@ -34,13 +36,10 @@ class PegasusT5(Buff, HFCompatible):
         from transformers import PegasusForConditionalGeneration, PegasusTokenizer
 
         self.device = self._select_hf_device()
-        model_kwargs = self._gather_hf_params(
-            hf_constructor=PegasusForConditionalGeneration.from_pretrained
-        )  # will defer to device_map if device map was `auto` may not match self.device
         self.para_model = PegasusForConditionalGeneration.from_pretrained(
-            self.para_model_name, **model_kwargs
+            self.para_model_name
         ).to(self.device)
-        self.tokenizer = PegasusTokenizer.from_pretrained(self.para_model_name, **model_kwargs)
+        self.tokenizer = PegasusTokenizer.from_pretrained(self.para_model_name)
 
     def _get_response(self, input_text):
         if self.para_model is None:

--- a/garak/buffs/paraphrase.py
+++ b/garak/buffs/paraphrase.py
@@ -91,7 +91,6 @@ class Fast(Buff, HFCompatible):
         self.no_repeat_ngram_size = 2
         # self.temperature = 0.7
         self.max_length = 128
-        self.device = None
         self.tokenizer = None
         self.para_model = None
         super().__init__(config_root=config_root)

--- a/garak/buffs/paraphrase.py
+++ b/garak/buffs/paraphrase.py
@@ -34,11 +34,13 @@ class PegasusT5(Buff, HFCompatible):
         from transformers import PegasusForConditionalGeneration, PegasusTokenizer
 
         self.device = self._select_hf_device()
-
-        self.tokenizer = PegasusTokenizer.from_pretrained(self.para_model_name)
+        model_kwargs = self._gather_hf_params(
+            hf_constructor=PegasusForConditionalGeneration.from_pretrained
+        )  # will defer to device_map if device map was `auto` may not match self.device
         self.para_model = PegasusForConditionalGeneration.from_pretrained(
-            self.para_model_name
+            self.para_model_name, **model_kwargs
         ).to(self.device)
+        self.tokenizer = PegasusTokenizer.from_pretrained(self.para_model_name, **model_kwargs)
 
     def _get_response(self, input_text):
         if self.para_model is None:

--- a/garak/buffs/paraphrase.py
+++ b/garak/buffs/paraphrase.py
@@ -16,7 +16,7 @@ class PegasusT5(Buff, HFCompatible):
 
     DEFAULT_PARAMS = Buff.DEFAULT_PARAMS | {
         "para_model_name": "garak-llm/pegasus_paraphrase",
-        "hf_args": {"device": "cpu", "torch_dtype": "float32"},
+        "hf_args": {"device": "cpu"}, # torch_dtype doesn't have standard support in Pegasus
         "max_length": 60,
         "temperature": 1.5,
     }

--- a/garak/detectors/base.py
+++ b/garak/detectors/base.py
@@ -12,8 +12,9 @@ from colorama import Fore, Style
 
 from garak import _config
 from garak.configurable import Configurable
-from garak.generators.huggingface import HFCompatible
 import garak.attempt
+
+from garak.resources.api.huggingface import HFCompatible
 
 
 class Detector(Configurable):

--- a/garak/generators/huggingface.py
+++ b/garak/generators/huggingface.py
@@ -14,11 +14,9 @@ be quite strong. Find your Hugging Face Inference API Key here:
  https://huggingface.co/docs/api-inference/quicktour
 """
 
-import inspect
 import logging
-import os
 import re
-from typing import Callable, List, Union
+from typing import List, Union
 import warnings
 
 import backoff
@@ -28,7 +26,7 @@ from PIL import Image
 from garak import _config
 from garak.exception import ModelNameMissingError, GarakException
 from garak.generators.base import Generator
-
+from garak.resources.api.huggingface import HFCompatible
 
 models_to_deprefix = ["gpt2"]
 
@@ -43,107 +41,6 @@ class HFLoadingException(GarakException):
 
 class HFInternalServerError(GarakException):
     pass
-
-
-class HFCompatible:
-    def _set_hf_context_len(self, config):
-        if hasattr(config, "n_ctx"):
-            if isinstance(config.n_ctx, int):
-                self.context_len = config.n_ctx
-
-    def _gather_hf_params(self, hf_constructor: Callable):
-        """ "Identify arguments that impact huggingface transformers resources and behavior"""
-
-        # this may be a bit too naive as it will pass any parameter valid for the hf_constructor signature
-        # this falls over when passed some `from_pretrained` methods as the callable model params are not always explicit
-        params = (
-            self.hf_args
-            if hasattr(self, "hf_args") and isinstance(self.hf_args, dict)
-            else {}
-        )
-        if params is not None and not "device" in params and hasattr(self, "device"):
-            # consider setting self.device in all cases or if self.device is not found raise error `_select_hf_device` must be called
-            params["device"] = self.device
-
-        args = {}
-
-        params_to_process = inspect.signature(hf_constructor).parameters
-
-        if "model" in params_to_process:
-            args["model"] = self.name
-            # expand for
-            params_to_process = {"do_sample": True} | params_to_process
-        else:
-            # callable is for a Pretrained class also map standard `pipeline` params
-            from transformers import pipeline
-
-            params_to_process = (
-                {"low_cpu_mem_usage": True}
-                | params_to_process
-                | inspect.signature(pipeline).parameters
-            )
-
-        for k in params_to_process:
-            if k == "model":
-                continue  # special case `model` comes from `name` in the generator
-            if k in params:
-                val = params[k]
-                if k == "torch_dtype" and hasattr(torch, val):
-                    args[k] = getattr(
-                        torch, val
-                    )  # some model type specific classes do not yet support direct string representation
-                    continue
-                if (
-                    k == "device"
-                    and "device_map" in params_to_process
-                    and "device_map" in params
-                ):
-                    # per transformers convention hold `device_map` before `device`
-                    continue
-                args[k] = params[k]
-
-        if (
-            not "device_map" in args
-            and "device_map" in params_to_process
-            and "device" in params_to_process
-            and "device" in args
-        ):
-            del args["device"]
-            args["device_map"] = self.device
-
-        return args
-
-    def _select_hf_device(self):
-        """Determine the most efficient device for tensor load, hold any existing `device` already selected"""
-        import torch.cuda
-
-        selected_device = None
-        if self.hf_args.get("device", None) is not None:
-            if isinstance(self.hf_args["device"], int):
-                # this assumes that indexed only devices selections means `cuda`
-                if self.hf_args["device"] < 0:
-                    msg = f"device {self.hf_args['device']} requested but CUDA device numbering starts at zero. Use 'device: cpu' to request CPU."
-                    logging.critical(msg)
-                    raise ValueError(msg)
-                selected_device = torch.device("cuda:" + str(self.hf_args["device"]))
-            else:
-                selected_device = torch.device(self.hf_args["device"])
-
-        if selected_device is None:
-            selected_device = torch.device(
-                "cuda"
-                if torch.cuda.is_available()
-                else "mps" if torch.backends.mps.is_available() else "cpu"
-            )
-
-        if isinstance(selected_device, torch.device) and selected_device.type == "mps":
-            os.environ["PYTORCH_ENABLE_MPS_FALLBACK"] = "1"
-            logging.debug("Enabled MPS fallback environment variable")
-
-        logging.debug(
-            "Using %s, based on torch environment evaluation", selected_device
-        )
-        return selected_device
 
 
 class Pipeline(Generator, HFCompatible):

--- a/garak/resources/api/huggingface.py
+++ b/garak/resources/api/huggingface.py
@@ -10,6 +10,9 @@ from typing import Callable
 
 class HFCompatible:
 
+    """Mixin class providing private utility methods for using Huggingface
+    transformers within garak"""
+
     def _set_hf_context_len(self, config):
         if hasattr(config, "n_ctx"):
             if isinstance(config.n_ctx, int):

--- a/garak/resources/api/huggingface.py
+++ b/garak/resources/api/huggingface.py
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: Portions Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import inspect
+import logging
+import os
+
+from typing import Callable
+
+
+class HFCompatible:
+
+    def _set_hf_context_len(self, config):
+        if hasattr(config, "n_ctx"):
+            if isinstance(config.n_ctx, int):
+                self.context_len = config.n_ctx
+
+    def _gather_hf_params(self, hf_constructor: Callable):
+        """ "Identify arguments that impact huggingface transformers resources and behavior"""
+        import torch
+
+        # this may be a bit too naive as it will pass any parameter valid for the hf_constructor signature
+        # this falls over when passed some `from_pretrained` methods as the callable model params are not always explicit
+        params = (
+            self.hf_args
+            if hasattr(self, "hf_args") and isinstance(self.hf_args, dict)
+            else {}
+        )
+        if params is not None and not "device" in params and hasattr(self, "device"):
+            # consider setting self.device in all cases or if self.device is not found raise error `_select_hf_device` must be called
+            params["device"] = self.device
+
+        args = {}
+
+        params_to_process = inspect.signature(hf_constructor).parameters
+
+        if "model" in params_to_process:
+            args["model"] = self.name
+            # expand for
+            params_to_process = {"do_sample": True} | params_to_process
+        else:
+            # callable is for a Pretrained class also map standard `pipeline` params
+            from transformers import pipeline
+
+            params_to_process = (
+                {"low_cpu_mem_usage": True}
+                | params_to_process
+                | inspect.signature(pipeline).parameters
+            )
+
+        for k in params_to_process:
+            if k == "model":
+                continue  # special case `model` comes from `name` in the generator
+            if k in params:
+                val = params[k]
+                if k == "torch_dtype" and hasattr(torch, val):
+                    args[k] = getattr(
+                        torch, val
+                    )  # some model type specific classes do not yet support direct string representation
+                    continue
+                if (
+                    k == "device"
+                    and "device_map" in params_to_process
+                    and "device_map" in params
+                ):
+                    # per transformers convention hold `device_map` before `device`
+                    continue
+                args[k] = params[k]
+
+        if (
+            not "device_map" in args
+            and "device_map" in params_to_process
+            and "device" in params_to_process
+            and "device" in args
+        ):
+            del args["device"]
+            args["device_map"] = self.device
+
+        return args
+
+    def _select_hf_device(self):
+        """Determine the most efficient device for tensor load, hold any existing `device` already selected"""
+        import torch
+
+        selected_device = None
+        if self.hf_args.get("device", None) is not None:
+            if isinstance(self.hf_args["device"], int):
+                # this assumes that indexed only devices selections means `cuda`
+                if self.hf_args["device"] < 0:
+                    msg = f"device {self.hf_args['device']} requested but CUDA device numbering starts at zero. Use 'device: cpu' to request CPU."
+                    logging.critical(msg)
+                    raise ValueError(msg)
+                selected_device = torch.device("cuda:" + str(self.hf_args["device"]))
+            else:
+                selected_device = torch.device(self.hf_args["device"])
+
+        if selected_device is None:
+            selected_device = torch.device(
+                "cuda"
+                if torch.cuda.is_available()
+                else "mps" if torch.backends.mps.is_available() else "cpu"
+            )
+
+        if isinstance(selected_device, torch.device) and selected_device.type == "mps":
+            os.environ["PYTORCH_ENABLE_MPS_FALLBACK"] = "1"
+            logging.debug("Enabled MPS fallback environment variable")
+
+        logging.debug(
+            "Using %s, based on torch environment evaluation", selected_device
+        )
+        return selected_device

--- a/tests/buffs/test_buffs_paraphrase.py
+++ b/tests/buffs/test_buffs_paraphrase.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from garak import _plugins
+
+BUFFS = [
+    classname
+    for (classname, active) in _plugins.enumerate_plugins("buffs")
+    if classname.startswith("buffs.paraphrase.")
+]
+
+
+@pytest.mark.parametrize("klassname", BUFFS)
+def test_buff_results(klassname):
+    b = _plugins.load_plugin(klassname)
+    b._load_model()
+    paraphrases = b._get_response("The rain in Spain falls mainly in the plains.")
+    assert len(paraphrases) > 0, "paraphrase buffs must return paraphrases"
+    assert len(paraphrases) == len(
+        set(paraphrases)
+    ), "Paraphrases should not have dupes"
+    assert not any([i == "" for i in paraphrases]), "No paraphrase may be empty"


### PR DESCRIPTION
`HFCompatible` was embedded in generators.base, tying slow-to-import HF-specific stuff to base classes. This PR moves `HFCompatible` to a separate module, with a candidate location in `garak.resources.api.huggingface`, enabling fast base class loading.
