### PR TITLE
generator: vision nims

### DIFF
--- a/garak/attempt.py
+++ b/garak/attempt.py
@@ -174,7 +174,7 @@ class Attempt:
         if name == "prompt":
             if value is None:
                 raise TypeError("'None' prompts are not valid")
-            assert isinstance(value, str)
+            # assert isinstance(value, str)
             self._add_first_turn("user", value)
 
         elif name == "outputs":

--- a/garak/attempt.py
+++ b/garak/attempt.py
@@ -174,7 +174,6 @@ class Attempt:
         if name == "prompt":
             if value is None:
                 raise TypeError("'None' prompts are not valid")
-            # assert isinstance(value, str)
             self._add_first_turn("user", value)
 
         elif name == "outputs":

--- a/garak/generators/base.py
+++ b/garak/generators/base.py
@@ -74,12 +74,10 @@ class Generator(Configurable):
 
     @staticmethod
     def _verify_model_result(result: List[Union[str, None]]):
-        assert isinstance(
-            result, list
-        ), "_call_model must return a list"
+        assert isinstance(result, list), "_call_model must return a list"
         assert (
-                len(result) == 1
-        ), "_call_model must return a list of one item when invoked as _call_model(prompt, 1)"
+            len(result) == 1
+        ), f"_call_model must return a list of one item when invoked as _call_model(prompt, 1), got {result}"
         assert (
             isinstance(result[0], str) or result[0] is None
         ), "_call_model's item must be a string or None"

--- a/garak/generators/huggingface.py
+++ b/garak/generators/huggingface.py
@@ -520,7 +520,10 @@ class Model(Pipeline, HFCompatible):
 
 
 class LLaVA(Generator, HFCompatible):
-    """Get LLaVA ([ text + image ] -> text) generations"""
+    """Get LLaVA ([ text + image ] -> text) generations
+
+    NB. This should be use with strict modality matching - generate() doesn't
+    support text-only prompts."""
 
     DEFAULT_PARAMS = Generator.DEFAULT_PARAMS | {
         "max_tokens": 4000,
@@ -570,6 +573,7 @@ class LLaVA(Generator, HFCompatible):
     def generate(
         self, prompt: str, generations_this_call: int = 1
     ) -> List[Union[str, None]]:
+
         text_prompt = prompt["text"]
         try:
             image_prompt = Image.open(prompt["image"])

--- a/garak/generators/nim.py
+++ b/garak/generators/nim.py
@@ -137,7 +137,7 @@ class NVOpenAICompletion(NVOpenAIChat):
         self.generator = self.client.completions
 
 
-class NIMVision(NVOpenAIChat):
+class Vision(NVOpenAIChat):
     """Wrapper for text+image to text NIMs. Expects NIM_API_KEY environment variable.
 
     Following generators.huggingface.LLaVa, expects prompts to be a dict with keys

--- a/garak/generators/nim.py
+++ b/garak/generators/nim.py
@@ -153,22 +153,28 @@ class NIMVision(NVOpenAIChat):
     def _prepare_prompt(self, prompt):
         import base64
 
+        if isinstance(prompt, str):
+            prompt = {"text": prompt, "image": None}
+
         text = prompt["text"]
         image_filename = prompt["image"]
-        with open(image_filename, "rb") as f:
-            image_b64 = base64.b64encode(f.read()).decode()
+        if image_filename is not None:
+            with open(image_filename, "rb") as f:
+                image_b64 = base64.b64encode(f.read()).decode()
 
-        if len(image_b64) > self.max_image_len:
-            logging.error(
-                "Image %s exceeds length limit. To upload larger images, use the assets API (not yet supported)",
-                image_filename,
+            if len(image_b64) > self.max_image_len:
+                logging.error(
+                    "Image %s exceeds length limit. To upload larger images, use the assets API (not yet supported)",
+                    image_filename,
+                )
+                return None
+
+            image_extension = prompt["image"].split(".")[-1].lower()
+            if image_extension == "jpg":  # image/jpg is not a valid mimetype
+                image_extension = "jpeg"
+            text = (
+                text + f' <img src="data:image/{image_extension};base64,{image_b64}" />'
             )
-            return None
-
-        image_extension = prompt["image"].split(".")[-1].lower()
-        if image_extension == "jpg":  # image/jpg is not a valid mimetype
-            image_extension = "jpeg"
-        text = text + f' <img src="data:image/{image_extension};base64,{image_b64}" />'
         return text
 
 

--- a/garak/generators/nim.py
+++ b/garak/generators/nim.py
@@ -85,7 +85,8 @@ class NVOpenAIChat(OpenAICompatible):
 
         prompt = self._prepare_prompt(prompt)
         if prompt is None:
-            return None  # if we didn't get a valid prompt, don't process & send NoneType downstream
+            # if we didn't get a valid prompt, don't process it, and send the NoneType(s) downstream
+            return [None] * generations_this_call
 
         try:
             result = super()._call_model(prompt, generations_this_call)
@@ -157,7 +158,7 @@ class NIMVision(NVOpenAIChat):
         with open(image_filename, "rb") as f:
             image_b64 = base64.b64encode(f.read()).decode()
 
-        if len(image_b64) < self.max_image_len:
+        if len(image_b64) > self.max_image_len:
             logging.error(
                 "Image %s exceeds length limit. To upload larger images, use the assets API (not yet supported)",
                 image_filename,

--- a/tests/harnesses/test_harnesses.py
+++ b/tests/harnesses/test_harnesses.py
@@ -6,6 +6,8 @@ import importlib
 
 from garak import _plugins
 
+import garak.harnesses.base
+
 HARNESSES = [
     classname for (classname, active) in _plugins.enumerate_plugins("harnesses")
 ]
@@ -25,3 +27,23 @@ def test_buff_structure(classname):
                 if k not in c._supported_params:
                     unsupported_defaults.append(k)
     assert unsupported_defaults == []
+
+
+def test_harness_modality_match():
+    t = {"text"}
+    ti = {"text", "image"}
+    tv = {"text", "vision"}
+    tvi = {"text", "vision", "image"}
+
+    # probe, generator
+    assert garak.harnesses.base._modality_match(t, t, True) is True
+    assert garak.harnesses.base._modality_match(ti, ti, True) is True
+    assert garak.harnesses.base._modality_match(t, tv, True) is False
+    assert garak.harnesses.base._modality_match(ti, t, True) is False
+
+    # when strict is false, generator must support all probe modalities, but can also support more
+    assert garak.harnesses.base._modality_match(t, t, False) is True
+    assert garak.harnesses.base._modality_match(ti, t, False) is False
+    assert garak.harnesses.base._modality_match(t, tvi, False) is True
+    assert garak.harnesses.base._modality_match(ti, tvi, False) is True
+    assert garak.harnesses.base._modality_match(t, ti, False) is True


### PR DESCRIPTION
resolves #691 

* New class `nim.NIMVision`, following the `huggingface.LLaVa` pattern
* New interstitial method in NIM.NVOpenAIChat that converts prompts to LLM input
* Relax a typing constraint in `attempt` to allow non-string prompts
* Specific messages for one exception type in `OpenAICompatible`


## Verification

- [ ] `garak -m nim.NIMVision -n microsoft/phi-3-vision-128k-instruct -p visual_jailbreak.FigStep -g 1 --parallel_attempts 16`
- [ ] **Verify** the thing does not do what it should not
- [ ] **Document** check the class doc in nim.NIMVision

Questions:

* Are we OK with the class name?
* Are we OK with the treatment of the oversized files in `NIMVision._prepare_prompt()` ?
* We need a pattern for modality matching/upgrading -- `huggingface.LLaVa` now needs strict matching. Tagging #602 for good and #658.
