### PR TITLE
feature: amend garak user-agent

### DIFF
--- a/docs/source/configurable.rst
+++ b/docs/source/configurable.rst
@@ -101,6 +101,7 @@ such as ``show_100_pass_modules``.
 * ``deprefix`` - Remove the prompt from the start of the output (some models return the prompt as part of their output)
 * ``seed`` - An optional random seed
 * ``eval_threshold`` - At what point in the 0..1 range output by detectors does a result count as a successful attack / hit
+* ``user_agent`` - What HTTP user agent string should garak use? ``{version}`` can be used to signify where garak version ID should go
 
 ``plugins`` config items
 """"""""""""""""""""""""

--- a/garak/_config.py
+++ b/garak/_config.py
@@ -155,6 +155,14 @@ def _store_config(settings_files) -> None:
     reporting = _set_settings(reporting, settings["reporting"])
 
 
+def _garak_user_agent(dummy=None):
+    global run
+    if hasattr(run, "user_agent"):
+        return run.user_agent
+    else:
+        return "garak"
+
+
 def set_all_http_lib_agents(agent_string):
     set_http_lib_agents(
         {"requests": agent_string, "httpx": agent_string, "aiohttp": agent_string}
@@ -165,7 +173,7 @@ def set_http_lib_agents(agent_strings: dict):
     if "requests" in agent_strings:
         from requests import utils
 
-        utils.default_user_agent = lambda x=None: agent_strings["requests"]
+        utils.default_user_agent = _garak_user_agent
     if "httpx" in agent_strings:
         import httpx
 

--- a/garak/_config.py
+++ b/garak/_config.py
@@ -153,9 +153,40 @@ def _store_config(settings_files) -> None:
     run.user_agent = run.user_agent.replace("{version}", version)
     plugins = _set_settings(plugins, settings["plugins"])
     reporting = _set_settings(reporting, settings["reporting"])
-    from requests import utils
 
-    utils.default_user_agent = run.user_agent
+
+def set_all_http_lib_agents(agent_string):
+    set_http_lib_agents(
+        {"requests": agent_string, "httpx": agent_string, "aiohttp": agent_string}
+    )
+
+
+def set_http_lib_agents(agent_strings: dict):
+    if "requests" in agent_strings:
+        from requests import utils
+
+        utils.default_user_agent = lambda x=None: agent_strings["requests"]
+    if "httpx" in agent_strings:
+        import httpx
+
+        httpx._client.USER_AGENT = agent_strings["httpx"]
+    if "aiohttp" in agent_strings:
+        import aiohttp
+
+        aiohttp.client_reqrep.SERVER_SOFTWARE = agent_strings["aiohttp"]
+
+
+def get_http_lib_agents():
+    from requests import utils
+    import httpx
+    import aiohttp
+
+    agent_strings = {}
+    agent_strings["requests"] = utils.default_user_agent
+    agent_strings["httpx"] = httpx._client.USER_AGENT
+    agent_strings["aiohttp"] = aiohttp.client_reqrep.SERVER_SOFTWARE
+
+    return agent_strings
 
 
 def load_base_config() -> None:

--- a/garak/_config.py
+++ b/garak/_config.py
@@ -23,9 +23,7 @@ from xdg_base_dirs import (
 
 DICT_CONFIG_AFTER_LOAD = False
 
-from garak import __version__
-
-version = __version__
+from garak import __version__ as version
 
 system_params = (
     "verbose narrow_output parallel_requests parallel_attempts skip_unknown".split()

--- a/garak/_config.py
+++ b/garak/_config.py
@@ -155,12 +155,17 @@ def _store_config(settings_files) -> None:
     reporting = _set_settings(reporting, settings["reporting"])
 
 
+# not my favourite solution in this module, but if
+# _config.set_http_lib_agents() to be predicated on a param instead of
+# a _config.run value (i.e. user_agent) - which it needs to be if it can be
+# used when the values are popped back to originals - then a separate way
+# of passing the UA string to _garak_user_agent() needs to exist, outside of
+# _config.run.user_agent
+REQUESTS_AGENT = ""
+
+
 def _garak_user_agent(dummy=None):
-    global run
-    if hasattr(run, "user_agent"):
-        return run.user_agent
-    else:
-        return "garak"
+    return str(REQUESTS_AGENT)
 
 
 def set_all_http_lib_agents(agent_string):
@@ -170,9 +175,13 @@ def set_all_http_lib_agents(agent_string):
 
 
 def set_http_lib_agents(agent_strings: dict):
+
+    global REQUESTS_AGENT
+
     if "requests" in agent_strings:
         from requests import utils
 
+        REQUESTS_AGENT = agent_strings["requests"]
         utils.default_user_agent = _garak_user_agent
     if "httpx" in agent_strings:
         import httpx

--- a/garak/_config.py
+++ b/garak/_config.py
@@ -150,7 +150,7 @@ def _store_config(settings_files) -> None:
     settings = _load_yaml_config(settings_files)
     system = _set_settings(system, settings["system"])
     run = _set_settings(run, settings["run"])
-    run.user_agent = run.user_agent.replace("{version}", garak.__version__)
+    run.user_agent = run.user_agent.replace("{version}", version)
     plugins = _set_settings(plugins, settings["plugins"])
     reporting = _set_settings(reporting, settings["reporting"])
 

--- a/garak/_config.py
+++ b/garak/_config.py
@@ -23,7 +23,9 @@ from xdg_base_dirs import (
 
 DICT_CONFIG_AFTER_LOAD = False
 
-version = -1  # eh why this is here? hm. who references it
+from garak import __version__
+
+version = __version__
 
 system_params = (
     "verbose narrow_output parallel_requests parallel_attempts skip_unknown".split()
@@ -144,10 +146,13 @@ def _load_yaml_config(settings_filenames) -> dict:
 
 
 def _store_config(settings_files) -> None:
+    import garak
+
     global system, run, plugins, reporting
     settings = _load_yaml_config(settings_files)
     system = _set_settings(system, settings["system"])
     run = _set_settings(run, settings["run"])
+    run.user_agent = run.user_agent.replace("{version}", garak.__version__)
     plugins = _set_settings(plugins, settings["plugins"])
     reporting = _set_settings(reporting, settings["reporting"])
 
@@ -193,6 +198,7 @@ def load_config(
 
     logging.debug("Loading configs from: %s", ",".join(settings_files))
     _store_config(settings_files=settings_files)
+
     if DICT_CONFIG_AFTER_LOAD:
         _lock_config_as_dict()
     loaded = True

--- a/garak/_config.py
+++ b/garak/_config.py
@@ -153,6 +153,9 @@ def _store_config(settings_files) -> None:
     run.user_agent = run.user_agent.replace("{version}", version)
     plugins = _set_settings(plugins, settings["plugins"])
     reporting = _set_settings(reporting, settings["reporting"])
+    from requests import utils
+
+    utils.default_user_agent = run.user_agent
 
 
 def load_base_config() -> None:

--- a/garak/cli.py
+++ b/garak/cli.py
@@ -10,13 +10,12 @@ def main(arguments=None) -> None:
     """Main entry point for garak runs invoked from the CLI"""
     import datetime
 
-    from garak import __version__, __description__
+    from garak import __description__
     from garak import _config
     from garak.exception import GarakException
 
     _config.transient.starttime = datetime.datetime.now()
     _config.transient.starttime_iso = _config.transient.starttime.isoformat()
-    _config.version = __version__
 
     if arguments is None:
         arguments = []

--- a/garak/cli.py
+++ b/garak/cli.py
@@ -254,6 +254,7 @@ def main(arguments=None) -> None:
 
     # load site config before loading CLI config
     _cli_config_supplied = args.config is not None
+    prior_user_agents = _config.get_http_lib_agents()
     _config.load_config(run_config_filename=args.config)
 
     # extract what was actually passed on CLI; use a masking argparser
@@ -553,3 +554,5 @@ def main(arguments=None) -> None:
     except (ValueError, GarakException) as e:
         logging.exception(e)
         print(e)
+
+    _config.set_http_lib_agents(prior_user_agents)

--- a/garak/generators/rest.py
+++ b/garak/generators/rest.py
@@ -67,6 +67,7 @@ class RestGenerator(Generator):
         self.escape_function = self._json_escape
         self.retry_5xx = True
         self.key_env_var = self.ENV_VAR if hasattr(self, "ENV_VAR") else None
+        self.user_agent = _config.run.user_agent
 
         # load configuration since super.__init__ has not been called
         self._load_config(config_root)
@@ -187,6 +188,8 @@ class RestGenerator(Generator):
         # serialized as parameters, in general a method could be created to add
         # the prompt data to a request via params or data based on the action verb
         data_kw = "params" if self.http_function == requests.get else "data"
+        if "User-Agent" not in request_headers:
+            request_headers["User-Agent"] = self.user_agent
         req_kArgs = {
             data_kw: request_data,
             "headers": request_headers,

--- a/garak/generators/rest.py
+++ b/garak/generators/rest.py
@@ -67,7 +67,6 @@ class RestGenerator(Generator):
         self.escape_function = self._json_escape
         self.retry_5xx = True
         self.key_env_var = self.ENV_VAR if hasattr(self, "ENV_VAR") else None
-        self.user_agent = _config.run.user_agent
 
         # load configuration since super.__init__ has not been called
         self._load_config(config_root)
@@ -188,8 +187,6 @@ class RestGenerator(Generator):
         # serialized as parameters, in general a method could be created to add
         # the prompt data to a request via params or data based on the action verb
         data_kw = "params" if self.http_function == requests.get else "data"
-        if "User-Agent" not in request_headers:
-            request_headers["User-Agent"] = self.user_agent
         req_kArgs = {
             data_kw: request_data,
             "headers": request_headers,

--- a/garak/harnesses/base.py
+++ b/garak/harnesses/base.py
@@ -64,6 +64,13 @@ class Harness(Configurable):
                     logging.warning(err_msg)
                     continue
 
+    def _start_run_hook(self):
+        self._http_lib_user_agents = _config.get_http_lib_agents()
+        _config.set_all_http_lib_agents(_config.run.user_agent)
+
+    def _end_run_hook(self):
+        _config.set_http_lib_agents(self._http_lib_user_agents)
+
     def run(self, model, probes, detectors, evaluator, announce_probe=True) -> None:
         """Core harness method
 
@@ -91,6 +98,8 @@ class Harness(Configurable):
             if hasattr(_config.system, "verbose") and _config.system.verbose >= 2:
                 print(msg)
             raise ValueError(msg)
+
+        self._start_run_hook()
 
         for probe in probes:
             logging.debug("harness: probe start for %s", probe.probename)
@@ -134,5 +143,7 @@ class Harness(Configurable):
                 )
             else:
                 evaluator.evaluate(attempt_results)
+
+        self._end_run_hook()
 
         logging.debug("harness: probe list iteration completed")

--- a/garak/resources/garak.core.yaml
+++ b/garak/resources/garak.core.yaml
@@ -13,7 +13,7 @@ run:
   eval_threshold: 0.5
   generations: 5
   probe_tags:
-  user_agent: "garak/{version} , LLM vulnerability scanner https://garak.ai"
+  user_agent: "garak/{version} (LLM vulnerability scanner https://garak.ai)"
 
 plugins:
   model_type:

--- a/garak/resources/garak.core.yaml
+++ b/garak/resources/garak.core.yaml
@@ -13,6 +13,7 @@ run:
   eval_threshold: 0.5
   generations: 5
   probe_tags:
+  user_agent: "garak LLM vulnerability scanner, v{version} https://garak.ai"
 
 plugins:
   model_type:

--- a/garak/resources/garak.core.yaml
+++ b/garak/resources/garak.core.yaml
@@ -13,7 +13,7 @@ run:
   eval_threshold: 0.5
   generations: 5
   probe_tags:
-  user_agent: "garak LLM vulnerability scanner, v{version} https://garak.ai"
+  user_agent: "garak/{version} , LLM vulnerability scanner https://garak.ai"
 
 plugins:
   model_type:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,8 @@ tests = [
   "pytest>=8.0",
   "requests-mock==1.12.1",
   "respx>=0.21.1",
-  "pytest-cov>=5.0.0"
+  "pytest-cov>=5.0.0",
+  "pytest_httpserver>=1.1.0"
 ]
 lint = [
   "black==24.4.2",

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,6 +41,7 @@ pytest>=8.0
 requests-mock==1.12.1
 respx>=0.21.1
 pytest-cov>=5.0.0
+pytest_httpserver>=1.1.0
 # lint
 black==24.4.2
 pylint>=3.1.0

--- a/tests/generators/test_rest.py
+++ b/tests/generators/test_rest.py
@@ -14,6 +14,7 @@ DEFAULT_TEXT_RESPONSE = "Here's your model response"
 
 @pytest.fixture
 def set_rest_config():
+    _config.run.user_agent = "test user agent, garak.ai"
     _config.plugins.generators["rest"] = {}
     _config.plugins.generators["rest"]["RestGenerator"] = {
         "name": DEFAULT_NAME,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,6 +9,7 @@ import shutil
 import sys
 import tempfile
 
+import aiohttp.client_reqrep
 import pytest
 
 from pathlib import Path
@@ -764,3 +765,21 @@ def test_nested():
 
     _config.plugins.generators["a"]["b"]["c"]["d"] = "e"
     assert _config.plugins.generators["a"]["b"]["c"]["d"] == "e"
+
+
+def test_get_user_agents():
+    agents = _config.get_http_lib_agents()
+    assert isinstance(agents, dict)
+
+
+def test_set_agents():
+    from requests import utils
+    import httpx
+    import aiohttp
+
+    agent_test = "garak/9 - only simple tailors edition"
+    _config.set_all_http_lib_agents(agent_test)
+
+    assert str(utils.default_user_agent()) == agent_test
+    assert httpx._client.USER_AGENT == agent_test
+    assert aiohttp.client_reqrep.SERVER_SOFTWARE == agent_test


### PR DESCRIPTION
We should be good citizens and not use the default `requests` user-agent, but instead our own

* add new run-level config param for useragent
* use this in generators using requests library

## Verification

List the steps needed to make sure this thing works

- drawing a blank here for now. maybe when this comes out of draft, we can use `requests-mock`