### PR TITLE
docs: centralise faq

### DIFF
--- a/docs/source/_config.rst
+++ b/docs/source/_config.rst
@@ -9,7 +9,7 @@ These are broken into the following major categories:
 * system: options that don't affect the security assessment
 * run: options that describe how a garak run will be conducted
 * plugins: config for plugins (generators, probes, detectors, buffs)
-* transient: internal values local to a single garak execution
+* transient: internal values local to a single ``garak`` execution
 
 Config values are loaded in the following priority (lowest-first):
 

--- a/docs/source/_plugins.rst
+++ b/docs/source/_plugins.rst
@@ -6,7 +6,7 @@ garak._plugins
 --------------
 
 This module manages plugin enumeration and loading. 
-There is one class per plugin in garak.
+There is one class per plugin in ``garak``.
 Enumerating the classes, with e.g. ``--list_probes`` on the command line, means importing each module.
 Therefore, modules should do as little as possible on load, and delay
 intensive activities (like loading classifiers) until a plugin's class is instantiated.

--- a/docs/source/attempt.rst
+++ b/docs/source/attempt.rst
@@ -1,3 +1,5 @@
+garak.attempt
+=============
 
 In garak, ``attempt`` objects track a single prompt and the results of running it on through the generator.
 Probes work by creating a set of garak.attempt objects and setting their class properties.

--- a/docs/source/basic.rst
+++ b/docs/source/basic.rst
@@ -1,9 +1,9 @@
-Top-level concepts in garak
-===========================
+Top-level concepts in ``garak``
+===============================
 
 What are we doing here, and how does it all fit together?
 Our goal is to test the security of something that takes prompts 
-and returns text. garak has a few constructs used to simplify and 
+and returns text. ``garak`` has a few constructs used to simplify and 
 organise this process.
 
 
@@ -28,7 +28,7 @@ attempt
 Attempts represent one unique try at breaking the target. A probe wraps
 up each of its adversarial interactions in an attempt object, and passes this
 to the generator. The generator adds responses into the attempt and sends
-the attempt back. This is logged in garak reporting which contains (among other
+the attempt back. This is logged in ``garak`` reporting which contains (among other
 things) JSON dumps of attempts.
 
 Once the probe is done with the attempt and the generator has added its 
@@ -58,7 +58,7 @@ to an object containing pass/fail data for a specific probe and detector pair.
 
 harnesses
 ---------
-The harnesses manage orchestration of a garak run. They select probes, then 
+The harnesses manage orchestration of a ``garak`` run. They select probes, then 
 detectors, and co-ordinate running probes, passing results to detectors, and 
 doing the final evaluation
 

--- a/docs/source/configurable.rst
+++ b/docs/source/configurable.rst
@@ -9,7 +9,7 @@ of exactly how each plugin behaves.
 Specifying custom configuration
 -------------------------------
 
-Garak can be configured in multiple ways:
+``garak`` can be configured in multiple ways:
 
 * Via command-line parameters
 * Using YAML configs

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -4,15 +4,15 @@ Contributing
 Getting ready
 -------------
 
-Garak's codebase is managed using github.
-The best and only way to contribute to garak is to start by getting a copy of the source code.
-You can use github's fork function to do this, which makes a copy of the garak codebase under your github user.
+``garak``'s codebase is managed using github.
+The best and only way to contribute to ``garak`` is to start by getting a copy of the source code.
+You can use github's fork function to do this, which makes a copy of the ``garak`` codebase under your github user.
 In there, you can edit code and build.
 Once you're done, make a pull request to the main repo and describe what you've done -- and we'll take it from there!
 
 
-Connecting with the garak team & community
-------------------------------------------
+Connecting with the ``garak`` team & community
+----------------------------------------------
 
 If you're going to contribute, it's a really good idea to reach out, so you have a source of help nearby, and so that we can make sure your valuable coding time is spent efficiently as a contributor.
 There are a number of ways you can reach out to us:
@@ -77,7 +77,7 @@ You can test your code in a few ways:
 * Start an interactive Python session
    * Import the model, e.g. `import garak.probes.mymodule`
    * Instantiate the plugin, e.g. `p = garak.probes.mymodule.MyProbe()`
-* Get `garak` to list all the plugins of the type you're writing, with `--list_probes`, `--list_detectors`, or `--list_generators`: `python3 -m garak --list_probes`
+* Get ``garak`` to list all the plugins of the type you're writing, with `--list_probes`, `--list_detectors`, or `--list_generators`: `python3 -m garak --list_probes`
 * Run a scan with test plugins
    * For probes, try a blank generator and always.Pass detector: `python3 -m garak -m test.Blank -p mymodule -d always.Pass`
    * For detectors, try a blank generator and a blank probe: `python3 -m garak -m test.Blank -p test.Blank -d mymodule`
@@ -90,7 +90,7 @@ All the tests should pass for any code there's a pull request for, and all tests
 Testing before sending a pull request
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Only code that passes the garak tests can be merged. Contributions must pass all tests.
+Only code that passes the ``garak`` tests can be merged. Contributions must pass all tests.
 
 Please write running tests to validate any new components or functions that you add.
 They're pretty straightforward - you can look at the existing code in `tests` to get an idea of how to write these.

--- a/docs/source/how.rst
+++ b/docs/source/how.rst
@@ -1,5 +1,5 @@
-How garak runs
-==============
+How ``garak`` runs
+==================
 
 In a typical run, ``garak`` will read a model type (and optionally model name) 
 from the command line, then determine which ``probe`` and ``detector`` plugins to run, 
@@ -14,7 +14,8 @@ plugins.
 * `garak/generators/` - plugins for LLMs to be probed
 * `garak/harnesses/` - classes for structuring testing
 * `garak/buffs` - classes for augmenting / fuzzing attacks
-* `resources/` - ancillary items required by plugins
+* `data/` - ancillary data
+* `resources/` - ancillary code
 
 The default operating mode is to use the :class:`garak.harnesses.probewise` harness. Given a list of 
 probe module names and probe plugin names, the ``probewise`` harness instantiates 
@@ -29,6 +30,6 @@ descends from :class:`garak.generators.base.Generator`.
 
 Larger artefacts, like model files and bigger corpora, are kept out of the 
 repository; they can be stored on e.g. Hugging Face Hub and loaded locally 
-by clients using garak.
+by clients using ``garak``.
 
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -39,6 +39,7 @@ Using garak
    how
    usage
    reporting
+   `FAQ <https://github.com/leondz/garak/blob/main/FAQ.md>`_
 
 Advanced usage
 ^^^^^^^^^^^^^^

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -38,7 +38,6 @@ Using garak
 
    how
    usage
-   reporting
    `FAQ <https://github.com/leondz/garak/blob/main/FAQ.md>`_
 
 Advanced usage

--- a/docs/source/payloads.rst
+++ b/docs/source/payloads.rst
@@ -2,7 +2,7 @@ garak.payloads
 ==============
 
 This module co-ordinates and provides for dynamic switching of "payloads"
-with garak. Payloads are items intended for inserting in prompts, that
+with ``garak``. Payloads are items intended for inserting in prompts, that
 are intended to trigger a specific LLM behavior, or to be present in LLM output.
 
 A payload can affect how we detect whether a probe was successful. For example,

--- a/docs/source/report.rst
+++ b/docs/source/report.rst
@@ -1,8 +1,35 @@
 garak.report
 ============
 
-garak's reports connect to things interested in consuming info on 
-LLM vulnerabilities and failures.
+``garak``'s reports connect to things interested in consuming info on 
+LLM vulnerabilities and failures, such as the AI Vulnerability Database.
+
+``garak`` provides a CLI option to further structure this file for downstream consumption. 
+The open data schema of AI vulnerability Database (`AVID <https://avidml.org>`_) is used for this purpose.
+
+The syntax for this is as follows:
+
+.. code-block:: console
+
+   python3 -m garak -r <path_to_file>
+
+Examples
+^^^^^^^^
+
+As an example, let's load up a ``garak`` report from scanning ``gpt-3.5-turbo-0613``.
+
+.. code-block:: console
+
+   wget https://gist.githubusercontent.com/shubhobm/9fa52d71c8bb36bfb888eee2ba3d18f2/raw/ef1808e6d3b26002d9b046e6c120d438adf49008/gpt35-0906.report.jsonl
+   python3 -m garak -r gpt35-0906.report.jsonl
+
+
+This produces the following output.
+
+.. code-block:: console
+
+   📜 Converting garak reports gpt35-0906.report.jsonl
+   📜 AVID reports generated at gpt35-0906.avid.jsonl
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/reporting.rst
+++ b/docs/source/reporting.rst
@@ -1,34 +1,6 @@
 Reporting
 =========
 
-.. automodule:: garak.buffs
-   :members:
-   :undoc-members:
-   :show-inheritance:   
 
 
-By default, ``garak`` outputs a JSONL file, with the name ``garak.<uuid>.report.jsonl``, that stores outcomes from a scan. ``garak`` provides a CLI option to further structure this file for downstream consumption. The open data schema of AI vulnerability Database (`AVID <https://avidml.org>`_) is used for this purpose.
-
-The syntax for this is as follows:
-
-.. code-block:: console
-
-   python3 -m garak -r <path_to_file>
-
-Examples
-^^^^^^^^
-
-As an example, let's load up a ``garak`` report from scanning ``gpt-3.5-turbo-0613``.
-
-.. code-block:: console
-
-   wget https://gist.githubusercontent.com/shubhobm/9fa52d71c8bb36bfb888eee2ba3d18f2/raw/ef1808e6d3b26002d9b046e6c120d438adf49008/gpt35-0906.report.jsonl
-   python3 -m garak -r gpt35-0906.report.jsonl
-
-
-This produces the following output.
-
-.. code-block:: console
-
-   📜 Converting garak reports gpt35-0906.report.jsonl
-   📜 AVID reports generated at gpt35-0906.avid.jsonl
+By default, ``garak`` outputs a JSONL file, with the name ``garak.<uuid>.report.jsonl``, that stores outcomes from a scan. 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -6,9 +6,10 @@ Usage
 Installation
 ------------
 
-`garak` is a command-line tool. It's developed in Linux and OSX.
+``garak`` is a command-line tool. It's developed in Linux and OSX.
 
-Friendly install instructions are at `<https://docs.garak.ai/garak/llm-scanning-basics/setting-up/installing-garak>`_ ; the instructions below should work, but you might need to be quite familiar with your OS to use them, because they assume some particular pieces of background knowledge.
+Friendly install instructions are at `<https://docs.garak.ai/garak/llm-scanning-basics/setting-up/installing-garak>`_ .
+The instructions below will work, but you might need to be quite familiar with your OS to use them, because they assume some particular pieces of background knowledge.
 
 Standard quick `pip` install
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -23,7 +24,7 @@ To use garak, first install it using pip:
 Install development version with `pip`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The standard pip version of `garak` is updated periodically. To get a fresher version, from GitHub, try:
+The standard pip version of ``garak`` is updated periodically. To get a fresher version, from GitHub, try:
 
 .. code-block:: console
 
@@ -33,9 +34,9 @@ The standard pip version of `garak` is updated periodically. To get a fresher ve
 For development: clone from `git`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-You can also clone the source and run `garak` directly. This works fine and is recommended for development.
+You can also clone the source and run ``garak`` directly. This works fine and is recommended for development.
 
-`garak` has its own dependencies. You can to install `garak` in its own Conda environment:
+``garak`` has its own dependencies. You can to install ``garak`` in its own Conda environment:
 
 .. code-block:: console
 
@@ -58,15 +59,21 @@ The general syntax is:
 
     garak <options>
 
-`garak` needs to know what model to scan, and by default, it'll try all the probes it knows on that model, using the vulnerability detectors recommended by each probe. You can see a list of probes using:
+``garak`` needs to know what model to scan, and by default, it'll try all the probes it knows on that model, using the vulnerability detectors recommended by each probe. You can see a list of probes using:
 
 .. code-block:: console
 
     garak --list_probes
 
-To specify a generator, use the ``--model_name`` and, optionally, the ``--model_type`` options. Model name specifies a model family/interface; model type specifies the exact model to be used. The "Intro to generators" section below describes some of the generators supported. A straightfoward generator family is Hugging Face models; to load one of these, set ``--model_name`` to ``huggingface`` and ``--model_type`` to the model's name on Hub (e.g. "RWKV/rwkv-4-169m-pile"). Some generators might need an API key to be set as an environment variable, and they'll let you know if they need that.
+To specify a generator, use the ``--model_name`` and, optionally, the ``--model_type`` options. 
+Model name specifies a model family/interface; model type specifies the exact model to be used. 
+The "Intro to generators" section below describes some of the generators supported. 
+A straightfoward generator family is Hugging Face models; to load one of these, set ``--model_name`` to ``huggingface`` and ``--model_type`` to the model's name on Hub (e.g. "RWKV/rwkv-4-169m-pile"). 
+Some generators might need an API key to be set as an environment variable, and they'll let you know if they need that.
 
-`garak` runs all the probes by default, but you can be specific about that too. ``--probes promptinject`` will use only the `PromptInject <https://github.com/agencyenterprise/promptinject>`_ framework's methods, for example. You can also specify one specific plugin instead of a plugin family by adding the plugin name after a ``.``; for example, ``--probes lmrc.SlurUsage`` will use an implementation of checking for models generating slurs based on the `Language Model Risk Cards <https://arxiv.org/abs/2303.18190>`_ framework.
+``garak`` runs all the probes by default, but you can be specific about that too. 
+``--probes promptinject`` will use only the `PromptInject <https://github.com/agencyenterprise/promptinject>`_ framework's methods, for example. 
+You can also specify one specific plugin instead of a plugin family by adding the plugin name after a ``.``; for example, ``--probes lmrc.SlurUsage`` will use an implementation of checking for models generating slurs based on the `Language Model Risk Cards <https://arxiv.org/abs/2303.18190>`_ framework.
 
 
 Examples


### PR DESCRIPTION
Add FAQ link to reference docs.

Tidy reference docs (formatting, add links)

resolves #887 