### PR TITLE
fix: add garak/data to pip package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,6 +7,7 @@ garak/generators
 garak/harnesses
 garak/probes
 garak/resources
+garak/data
 
 include *.md
 include *.txt
@@ -14,3 +15,4 @@ recursive-include garak *.py
 recursive-include garak/analyze *.py *.jinja
 recursive-include garak/configs *.yaml
 recursive-include garak/resources *
+recursive-include garak/data *


### PR DESCRIPTION
Ensure pip install package include all `garak/data` files.

## Verification

- [ ] Install via pip repository reference in a clean env (example base on `ubuntu:latest` docker container)
``` shell
apt-get update; apt-get install python3 python3-venv git
python3 -m venv garak
source garak/bin/activate
python -m pip install -U git+https://github.com/jmartin-tech/garak.git@fix/include-data-in-packaging
```
- [ ] `ls -lah garak/lib/python3.12/site-packages/garak/data`
- [ ] **Verify** files such as `misp_descriptions.tsv` are reporting as on disk
