### PR TITLE
feature: reinforce `trust_remote_code=False`

### DIFF
--- a/garak/buffs/paraphrase.py
+++ b/garak/buffs/paraphrase.py
@@ -39,7 +39,9 @@ class PegasusT5(Buff, HFCompatible):
         self.para_model = PegasusForConditionalGeneration.from_pretrained(
             self.para_model_name
         ).to(self.device)
-        self.tokenizer = PegasusTokenizer.from_pretrained(self.para_model_name)
+        self.tokenizer = PegasusTokenizer.from_pretrained(
+            self.para_model_name, trust_remote_code=False
+        )
 
     def _get_response(self, input_text):
         if self.para_model is None:

--- a/garak/buffs/paraphrase.py
+++ b/garak/buffs/paraphrase.py
@@ -40,7 +40,7 @@ class PegasusT5(Buff, HFCompatible):
             self.para_model_name
         ).to(self.device)
         self.tokenizer = PegasusTokenizer.from_pretrained(
-            self.para_model_name, trust_remote_code=False
+            self.para_model_name, trust_remote_code=self.hf_args["trust_remote_code"]
         )
 
     def _get_response(self, input_text):

--- a/garak/buffs/paraphrase.py
+++ b/garak/buffs/paraphrase.py
@@ -39,8 +39,13 @@ class PegasusT5(Buff, HFCompatible):
         self.para_model = PegasusForConditionalGeneration.from_pretrained(
             self.para_model_name
         ).to(self.device)
+        trust_remote_code = (
+            self.hf_args["trust_remote_code"]
+            if "trust_remote_code" in self.hf_args
+            else False
+        )
         self.tokenizer = PegasusTokenizer.from_pretrained(
-            self.para_model_name, trust_remote_code=self.hf_args["trust_remote_code"]
+            self.para_model_name, trust_remote_code=trust_remote_code
         )
 
     def _get_response(self, input_text):

--- a/garak/buffs/paraphrase.py
+++ b/garak/buffs/paraphrase.py
@@ -17,7 +17,8 @@ class PegasusT5(Buff, HFCompatible):
     DEFAULT_PARAMS = Buff.DEFAULT_PARAMS | {
         "para_model_name": "garak-llm/pegasus_paraphrase",
         "hf_args": {
-            "device": "cpu"
+            "device": "cpu",
+            "trust_remote_code": False,
         },  # torch_dtype doesn't have standard support in Pegasus
         "max_length": 60,
         "temperature": 1.5,
@@ -39,13 +40,8 @@ class PegasusT5(Buff, HFCompatible):
         self.para_model = PegasusForConditionalGeneration.from_pretrained(
             self.para_model_name
         ).to(self.device)
-        trust_remote_code = (
-            self.hf_args["trust_remote_code"]
-            if "trust_remote_code" in self.hf_args
-            else False
-        )
         self.tokenizer = PegasusTokenizer.from_pretrained(
-            self.para_model_name, trust_remote_code=trust_remote_code
+            self.para_model_name, trust_remote_code=self.hf_args["trust_remote_code"]
         )
 
     def _get_response(self, input_text):

--- a/garak/generators/huggingface.py
+++ b/garak/generators/huggingface.py
@@ -436,15 +436,11 @@ class Model(Pipeline, HFCompatible):
         if _config.run.seed is not None:
             transformers.set_seed(_config.run.seed)
 
-        trust_remote_code = self.name.startswith("mosaicml/mpt-")
-
         model_kwargs = self._gather_hf_params(
             hf_constructor=transformers.AutoConfig.from_pretrained
         )  # will defer to device_map if device map was `auto` may not match self.device
 
-        self.config = transformers.AutoConfig.from_pretrained(
-            self.name, trust_remote_code=trust_remote_code, **model_kwargs
-        )
+        self.config = transformers.AutoConfig.from_pretrained(self.name, **model_kwargs)
 
         self._set_hf_context_len(self.config)
         self.config.init_device = self.device  # determined by Pipeline `__init__``

--- a/garak/resources/api/huggingface.py
+++ b/garak/resources/api/huggingface.py
@@ -9,7 +9,6 @@ from typing import Callable
 
 
 class HFCompatible:
-
     """Mixin class providing private utility methods for using Huggingface
     transformers within garak"""
 
@@ -78,6 +77,13 @@ class HFCompatible:
         ):
             del args["device"]
             args["device_map"] = self.device
+
+        # trust_remote_code reset to default disabled unless unlocked in garak HF item config
+        if (
+            "trust_remote_code" in params_to_process
+            and "trust_remote_code" not in params
+        ):
+            args["trust_remote_code"] = False
 
         return args
 


### PR DESCRIPTION
This change sets `trust_remote_code` to false regardless of HF function default, unless explicitly enabled in garak config

resolves #991 