### PR TITLE
generators: add option to specify HTTP codes to skip generation on, for `RestGenerator`

### DIFF
--- a/docs/source/garak.generators.rest.rst
+++ b/docs/source/garak.generators.rest.rst
@@ -16,7 +16,7 @@ Uses the following options from ``_config.plugins.generators["rest.RestGenerator
 * ``response_json_field`` - (optional) Which field of the response JSON should be used as the output string? Default ``text``. Can also be a JSONPath value, and ``response_json_field`` is used as such if it starts with ``$``.
 * ``request_timeout`` - How many seconds should we wait before timing out? Default 20
 * ``ratelimit_codes`` - Which endpoint HTTP response codes should be caught as indicative of rate limiting and retried? ``List[int]``, default ``[429]``
-* ``skip_codes`` - Which endpoint HTTP response code should lead to the generation being treated as not possible and skipped for this query. Takes precedence over ``skip_codes``.
+* ``skip_codes`` - Which endpoint HTTP response code should lead to the generation being treated as not possible and skipped for this query. Takes precedence over ``ratelimit_codes``.
 
 Templates can be either a string or a JSON-serialisable Python object.
 Instance of ``$INPUT`` here are replaced with the prompt; instances of ``$KEY``

--- a/docs/source/garak.generators.rest.rst
+++ b/docs/source/garak.generators.rest.rst
@@ -16,6 +16,7 @@ Uses the following options from ``_config.plugins.generators["rest.RestGenerator
 * ``response_json_field`` - (optional) Which field of the response JSON should be used as the output string? Default ``text``. Can also be a JSONPath value, and ``response_json_field`` is used as such if it starts with ``$``.
 * ``request_timeout`` - How many seconds should we wait before timing out? Default 20
 * ``ratelimit_codes`` - Which endpoint HTTP response codes should be caught as indicative of rate limiting and retried? ``List[int]``, default ``[429]``
+* ``skip_codes`` - Which endpoint HTTP response code should lead to the generation being treated as not possible and skipped for this query. Takes precedence over ``skip_codes``.
 
 Templates can be either a string or a JSON-serialisable Python object.
 Instance of ``$INPUT`` here are replaced with the prompt; instances of ``$KEY``

--- a/garak/generators/rest.py
+++ b/garak/generators/rest.py
@@ -56,6 +56,7 @@ class RestGenerator(Generator):
         "req_template_json_object",
         "request_timeout",
         "ratelimit_codes",
+        "skip_codes",
         "temperature",
         "top_k",
     )

--- a/garak/generators/rest.py
+++ b/garak/generators/rest.py
@@ -194,16 +194,17 @@ class RestGenerator(Generator):
             "timeout": self.request_timeout,
         }
         resp = self.http_function(self.uri, **req_kArgs)
-        if resp.status_code in self.ratelimit_codes:
-            raise RateLimitHit(
-                f"Rate limited: {resp.status_code} - {resp.reason}, uri: {self.uri}"
-            )
 
-        elif resp.status_code in self.skip_codes:
+        if resp.status_code in self.skip_codes:
             logging.debug(
                 f"REST skip prompt: {resp.status_code} - {resp.reason}, uri: {self.uri}"
             )
             return [None]
+
+        elif resp.status_code in self.ratelimit_codes:
+            raise RateLimitHit(
+                f"Rate limited: {resp.status_code} - {resp.reason}, uri: {self.uri}"
+            )
 
         elif str(resp.status_code)[0] == "3":
             raise NotImplementedError(

--- a/garak/generators/rest.py
+++ b/garak/generators/rest.py
@@ -231,7 +231,7 @@ class RestGenerator(Generator):
 
         response_object = json.loads(resp.content)
 
-        response = [None] * generations_this_call
+        response = [None]
 
         # if response_json_field starts with a $, treat is as a JSONPath
         assert (

--- a/tests/generators/test_rest.py
+++ b/tests/generators/test_rest.py
@@ -102,7 +102,7 @@ def test_rest_skip_code(requests_mock):
     generator = _plugins.load_plugin(
         "generators.rest.RestGenerator", config_root=_config
     )
-    generator.skip_codes = {200}
+    generator.skip_codes = [200]
     requests_mock.post(
         DEFAULT_URI,
         text=json.dumps(


### PR DESCRIPTION
Some prompts are difficult for some endpoints to respond to. This patch offers a way for garak to skip those prompts, if the generation failure is expressed in an endpoint HTTP response code (e.g. `400`)

## Verification
- [ ] Run the tests and ensure they pass `python -m pytest tests/`
- [ ] Run a restgenerator against an endpoint that returns 400; there should be a `None` returned by the generator and the probe should present as SKIP on the CLI
- [ ] Docs added in PR

## Context
Targets issue raised in https://discord.com/channels/1121536128269422654/1121536129099907190/1305844548181692416