### PR TITLE
Sanity test for pip install from repository

### DIFF
--- a/.github/workflows/remote_package_install.yml
+++ b/.github/workflows/remote_package_install.yml
@@ -14,7 +14,6 @@ jobs:
       matrix:
         python-version: ["3.10","3.12"]
     steps:
-      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/remote_package_install.yml
+++ b/.github/workflows/remote_package_install.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           python -m garak --model_type test.Blank --probes test.Test
           set +e
-          grep ERROR $HOME/.local/share/garak/garak.log
+          grep -E "(WARNING|ERROR|CRITICAL)" $HOME/.local/share/garak/garak.log
           if [ $? != 1 ]; then
             echo "Errors exist in the test log"
             exit 1

--- a/.github/workflows/remote_package_install.yml
+++ b/.github/workflows/remote_package_install.yml
@@ -1,0 +1,34 @@
+name: Garak pip - install from repo
+
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10","3.12"]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: pip install from repo
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -U git+https://github.com/${GITHUB_REPOSITORY}.git@${GITHUB_SHA}
+      - name: Sanity Test
+        run: |
+          python -m garak --model_type test.Blank --probes test.Test
+          set +e
+          grep ERROR $HOME/.local/share/garak/garak.log
+          if [ $? != 1 ]; then
+            echo "Errors exist in the test log"
+            exit 1
+          fi


### PR DESCRIPTION
Between releases the various installation processes need testing, this adds a basic integration test for early warning of `pip` based repository snapshot installs.

This verifies a simple test run will not result in any logged `ERROR` messages on the minimum python version and the latest supported version.