### PR TITLE
feature: add experimental features flag to be only accessible in core config

### DIFF
--- a/docs/source/configurable.rst
+++ b/docs/source/configurable.rst
@@ -92,6 +92,7 @@ such as ``show_100_pass_modules``.
 * ``verbose`` - Degree of verbosity (values above 0 are experimental, the report & log are authoritative)
 * ``narrow_output`` - Support output on narrower CLIs
 * ``show_z`` - Display Z-scores and visual indicators on CLI. It's good, but may be too much info until one has seen garak run a couple of times
+* ``enable_experimental`` - Enable experimental function CLI flags. Disabled by default. Experimental functions may disrupt your installation and provide unusual/unstable results. Can only be set by editing core config, so a git checkout of garak is recommended for this.
 
 ``run`` config items
 """"""""""""""""""""

--- a/garak/cli.py
+++ b/garak/cli.py
@@ -247,6 +247,11 @@ def main(arguments=None) -> None:
         help="Launch garak in interactive.py mode",
     )
 
+    ## EXPERIMENTAL FEATURES
+    if _config.system.enable_experimental:
+        # place parser argument defs for experimental features here
+        pass
+
     logging.debug("args - raw argument string received: %s", arguments)
 
     args = parser.parse_args(arguments)

--- a/garak/resources/garak.core.yaml
+++ b/garak/resources/garak.core.yaml
@@ -6,6 +6,7 @@ system:
   parallel_attempts: false
   lite: true
   show_z: false
+  enable_experimental: false
 
 run:
   seed:


### PR DESCRIPTION
add facility to unlock experimental CLI options if a core config flag is set

## Verification

- [ ] run `python -m garak --help`, experimental features should not be enabled
- [ ] change system.enable_experimental to `true` in `garak/resources/garak.core.yaml`
- [ ] run `python -m garak --help`, there should be a message between the usage summary and options that experimental features are enabled


>> Question - would this feature be better off in a site config? I'm concerned about `garak.core.yaml`'s value getting accidentally clobbered in a development commit